### PR TITLE
feat(postgres): add PostgresFlowRepository with TODO stubs

### DIFF
--- a/libs/ferrisquote-postgres/Cargo.toml
+++ b/libs/ferrisquote-postgres/Cargo.toml
@@ -6,3 +6,28 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+# Internal dependencies
+ferrisquote-domain = { path = "../ferrisquote-domain" }
+
+# Database
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+
+# Async runtime
+tokio = { version = "1.40", features = ["full"] }
+
+# Error handling
+thiserror = "1.0"
+anyhow = "1.0"
+
+# Logging
+tracing = "0.1"
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# UUID
+uuid = { version = "1.20", features = ["v7", "serde"] }
+
+# Date/Time
+chrono = { version = "0.4", features = ["serde"] }

--- a/libs/ferrisquote-postgres/src/lib.rs
+++ b/libs/ferrisquote-postgres/src/lib.rs
@@ -1,14 +1,3 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+pub mod repositories;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub use repositories::PostgresFlowRepository;

--- a/libs/ferrisquote-postgres/src/repositories/flow_repository.rs
+++ b/libs/ferrisquote-postgres/src/repositories/flow_repository.rs
@@ -1,0 +1,195 @@
+use ferrisquote_domain::domain::{
+    error::DomainError,
+    flows::{
+        entities::{
+            field::Field,
+            flow::Flow,
+            ids::{FieldId, FlowId, StepId},
+            step::Step,
+        },
+        ports::FlowRepository,
+    },
+};
+use sqlx::PgPool;
+use std::sync::Arc;
+
+/// PostgreSQL implementation of FlowRepository
+#[derive(Clone)]
+pub struct PostgresFlowRepository {
+    pool: Arc<PgPool>,
+}
+
+impl PostgresFlowRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool: Arc::new(pool),
+        }
+    }
+
+    pub fn with_pool(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+}
+
+impl FlowRepository for PostgresFlowRepository {
+    fn create_flow(
+        &self,
+        flow: Flow,
+    ) -> impl std::future::Future<Output = Result<Flow, DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL insert
+            // INSERT INTO flows (id, name, description, created_at, updated_at)
+            // VALUES ($1, $2, $3, NOW(), NOW())
+            todo!("Implement create_flow with PostgreSQL")
+        }
+    }
+
+    fn get_flow(
+        &self,
+        id: FlowId,
+    ) -> impl std::future::Future<Output = Result<Flow, DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL select with JOIN on steps and fields
+            // SELECT f.*, s.*, fi.*
+            // FROM flows f
+            // LEFT JOIN steps s ON s.flow_id = f.id
+            // LEFT JOIN fields fi ON fi.step_id = s.id
+            // WHERE f.id = $1
+            // ORDER BY s.order, fi.order
+            todo!("Implement get_flow with PostgreSQL")
+        }
+    }
+
+    fn list_flows(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<Flow>, DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL select all flows
+            // SELECT f.*,
+            //        COUNT(DISTINCT s.id) as step_count
+            // FROM flows f
+            // LEFT JOIN steps s ON s.flow_id = f.id
+            // GROUP BY f.id
+            // ORDER BY f.created_at DESC
+            todo!("Implement list_flows with PostgreSQL")
+        }
+    }
+
+    fn update_flow(
+        &self,
+        flow: Flow,
+    ) -> impl std::future::Future<Output = Result<Flow, DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL update
+            // UPDATE flows
+            // SET name = $2, description = $3, updated_at = NOW()
+            // WHERE id = $1
+            // RETURNING *
+            todo!("Implement update_flow with PostgreSQL")
+        }
+    }
+
+    fn delete_flow(
+        &self,
+        id: FlowId,
+    ) -> impl std::future::Future<Output = Result<(), DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL delete with cascade
+            // DELETE FROM flows WHERE id = $1
+            // Note: Cascade deletes should be handled by DB constraints
+            // ON DELETE CASCADE for steps and fields
+            todo!("Implement delete_flow with PostgreSQL")
+        }
+    }
+
+    fn create_step(
+        &self,
+        flow_id: FlowId,
+        step: Step,
+    ) -> impl std::future::Future<Output = Result<Step, DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL insert
+            // INSERT INTO steps (id, flow_id, title, description, order, created_at, updated_at)
+            // VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+            // RETURNING *
+            todo!("Implement create_step with PostgreSQL")
+        }
+    }
+
+    fn update_step(
+        &self,
+        step: Step,
+    ) -> impl std::future::Future<Output = Result<Step, DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL update
+            // UPDATE steps
+            // SET title = $2, description = $3, order = $4, updated_at = NOW()
+            // WHERE id = $1
+            // RETURNING *
+            todo!("Implement update_step with PostgreSQL")
+        }
+    }
+
+    fn delete_step(
+        &self,
+        id: StepId,
+    ) -> impl std::future::Future<Output = Result<(), DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL delete
+            // DELETE FROM steps WHERE id = $1
+            // Note: Fields should cascade delete via DB constraints
+            todo!("Implement delete_step with PostgreSQL")
+        }
+    }
+
+    fn create_field(
+        &self,
+        step_id: StepId,
+        field: Field,
+    ) -> impl std::future::Future<Output = Result<Field, DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL insert
+            // INSERT INTO fields (id, step_id, key, label, description, order, config, created_at, updated_at)
+            // VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+            // RETURNING *
+            // Note: config will be stored as JSONB
+            todo!("Implement create_field with PostgreSQL")
+        }
+    }
+
+    fn update_field(
+        &self,
+        field: Field,
+    ) -> impl std::future::Future<Output = Result<Field, DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL update
+            // UPDATE fields
+            // SET key = $2, label = $3, description = $4, order = $5, config = $6, updated_at = NOW()
+            // WHERE id = $1
+            // RETURNING *
+            todo!("Implement update_field with PostgreSQL")
+        }
+    }
+
+    fn delete_field(
+        &self,
+        id: FieldId,
+    ) -> impl std::future::Future<Output = Result<(), DomainError>> + Send {
+        async move {
+            // TODO: Implement PostgreSQL delete
+            // DELETE FROM fields WHERE id = $1
+            todo!("Implement delete_field with PostgreSQL")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TODO: Add integration tests with test database
+    // - Setup test database with sqlx migrations
+    // - Test CRUD operations
+    // - Test cascade deletes
+    // - Test concurrent access
+}

--- a/libs/ferrisquote-postgres/src/repositories/mod.rs
+++ b/libs/ferrisquote-postgres/src/repositories/mod.rs
@@ -1,0 +1,3 @@
+pub mod flow_repository;
+
+pub use flow_repository::PostgresFlowRepository;


### PR DESCRIPTION
- Create PostgresFlowRepository implementing FlowRepository trait
- Add sqlx dependencies with postgres, uuid, and chrono features
- All CRUD methods marked as TODO for future implementation
- Prepare structure for database integration

This allows the domain layer to remain pure while providing a clear contract for persistence implementation.