### PR TITLE
docs: libs documentation

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,33 @@
+# Apps
+
+Executable applications of the FerrisQuote monorepo.
+
+## Contents
+
+| Application | Description | Stack |
+|---|---|---|
+| [`ferrisquote-api`](./ferrisquote-api/) | REST API backend (port 3000) | Rust, Axum, SQLx, utoipa |
+| [`ferrisquote-webapp`](./ferrisquote-webapp/) | Web frontend (port 5173) | React 19, Vite, TanStack Query, XYFlow |
+
+## Relationship with libs
+
+```
+ferrisquote-api
+  ├── ferrisquote-domain    (business logic, entities, ports/traits)
+  └── ferrisquote-postgres  (PostgreSQL repository implementations)
+
+ferrisquote-webapp
+  └── API client generated from the ferrisquote-api OpenAPI spec
+```
+
+## Quick start
+
+```bash
+# Backend (from repo root)
+cargo run -p ferrisquote-api
+
+# Frontend
+cd apps/ferrisquote-webapp && pnpm dev
+```
+
+See `compose.yaml` at the repo root for a full setup with PostgreSQL.

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,0 +1,29 @@
+# Libs
+
+Shared libraries of the FerrisQuote monorepo. Each crate is self-contained and follows a hexagonal architecture (ports & adapters).
+
+## Contents
+
+| Crate | Role | Internal dependencies |
+|---|---|---|
+| [`ferrisquote-domain`](./ferrisquote-domain/) | Business core: entities, services, ports (traits) | None |
+| [`ferrisquote-auth`](./ferrisquote-auth/) | OIDC / JWT authentication (token validation via JWKS) | None |
+| [`ferrisquote-postgres`](./ferrisquote-postgres/) | PostgreSQL implementation of the repository traits | `ferrisquote-domain` |
+
+## Architecture overview
+
+```
+                   ferrisquote-api (app)
+                      │
+          ┌───────────┼───────────┐
+          ▼           ▼           ▼
+   ferrisquote-   ferrisquote-  ferrisquote-
+      auth          domain       postgres
+                      ▲              │
+                      └──────────────┘
+                   (implements the ports)
+```
+
+- **domain** has zero infrastructure dependencies (no I/O). It defines the traits (`FlowRepository`, `StepRepository`, etc.) that adapters implement.
+- **postgres** depends on **domain** to implement those traits using SQLx.
+- **auth** is standalone and communicates with an OIDC IdP over HTTP.

--- a/libs/ferrisquote-auth/README.md
+++ b/libs/ferrisquote-auth/README.md
@@ -1,0 +1,54 @@
+# ferrisquote-auth
+
+Authentication library for FerrisQuote. Handles OIDC JWT token validation using JWKS (JSON Web Key Sets).
+
+## Architecture
+
+```
+Token (JWT)
+  │
+  ▼
+AuthRepository trait (port)
+  │
+  ├── validate_token()  → Claims
+  └── identity()        → Identity
+  │
+  ▼
+FerrisKeyRepository (adapter)
+  └── Fetches JWKS from IdP → Decodes RS256 JWT → Validates expiry
+```
+
+## Entities
+
+| Entity | Description |
+|---|---|
+| `Claims` | Decoded JWT payload (sub, iss, aud, exp, email, preferred_username, etc.) |
+| `Identity` | Represents an authenticated user or client, derived from Claims |
+| `Token` | Token wrapper |
+| `Client` | OIDC client representation |
+| `User` | Authenticated user representation |
+
+## Port
+
+The `AuthRepository` trait defines two async methods:
+
+- `validate_token(token) -> Claims` -- decodes, verifies signature (RS256), and checks expiry
+- `identity(token) -> Identity` -- validates the token then maps claims to an `Identity`
+
+## Adapter: FerrisKeyRepository
+
+Concrete implementation that:
+
+1. Extracts `kid` from the JWT header
+2. Fetches the JWKS from `{issuer}/protocol/openid-connect/certs`
+3. Finds the matching public key
+4. Decodes and validates the token using `jsonwebtoken`
+5. Checks expiration (`exp` claim)
+
+## Testing
+
+The crate includes a full test suite with an embedded HTTP server that serves test JWKS, covering: invalid tokens, missing `kid`, network errors, expired tokens, and successful validation.
+
+```bash
+cargo test -p ferrisquote-auth
+```

--- a/libs/ferrisquote-domain/README.md
+++ b/libs/ferrisquote-domain/README.md
@@ -1,0 +1,46 @@
+# ferrisquote-domain
+
+Pure business logic crate for FerrisQuote. Contains entities, domain services, and repository/service port definitions (traits). This crate has **zero I/O dependencies** -- it never touches a database, network, or filesystem directly.
+
+## Domain modules
+
+### Flows
+
+The core domain. A **Flow** is a configurable quote template composed of ordered **Steps**, each containing ordered **Fields**.
+
+```
+Flow
+ └── Step (ordered by LexoRank)
+      └── Field (ordered by LexoRank, typed via FieldConfig)
+```
+
+**Entities:** `Flow`, `Step`, `Field`, `FieldConfig` (enum: Text, Number, Date, Boolean, Select)
+
+**Ports (traits):**
+
+| Trait | Role |
+|---|---|
+| `FlowRepository` | CRUD persistence for flows |
+| `StepRepository` | CRUD persistence for steps |
+| `FieldRepository` | CRUD persistence for fields |
+| `FlowService` | Flow-level business operations |
+| `StepService` | Step ordering, creation, deletion |
+| `FieldService` | Field creation, update, move between steps |
+
+**Service implementation:** `FlowServiceImpl<FR, SR, FDR, RS>` -- a generic orchestrator that implements all three service traits. It delegates persistence to injected repositories and uses a `RankService` to compute LexoRank ordering.
+
+### Estimator
+
+Estimation engine with variables and expression evaluation (via `evalexpr`).
+
+**Entities:** `Estimator`, `EstimatorVariable`
+
+### Rank
+
+Abstraction over LexoRank ordering. Provides a `RankService` trait with `initial()`, `between()`, `after()`, `before()` operations. The concrete implementation (`LexoRankProvider`) uses the `lexorank` crate.
+
+## Key design decisions
+
+- **Partial updates**: repository `update_*` methods accept `Option<T>` fields -- only `Some(...)` values are persisted, `None` fields are left untouched.
+- **LexoRank ordering**: steps and fields use string-based lexicographic ranks instead of integer positions, enabling reordering without renumbering.
+- **No async-trait macro**: port traits use `impl Future<Output = ...> + Send` return types (Rust edition 2024) instead of the `async-trait` proc macro.

--- a/libs/ferrisquote-postgres/README.md
+++ b/libs/ferrisquote-postgres/README.md
@@ -1,0 +1,85 @@
+# ferrisquote-postgres
+
+PostgreSQL persistence layer for FerrisQuote. Implements the repository traits defined in `ferrisquote-domain` using SQLx.
+
+## Architecture
+
+This crate is a **secondary adapter** in the hexagonal architecture: it depends on `ferrisquote-domain` and implements its port traits (`FlowRepository`, `StepRepository`, `FieldRepository`) against a real PostgreSQL database.
+
+```
+ferrisquote-domain (traits)
+        ▲
+        │ implements
+        │
+ferrisquote-postgres
+  └── PostgresFlowRepository (SQLx + PgPool)
+```
+
+## Repository
+
+`PostgresFlowRepository` holds an `sqlx::PgPool` and implements all three repository traits:
+
+- **FlowRepository** -- CRUD on the `flows` table
+- **StepRepository** -- CRUD on the `steps` table (with LexoRank ordering)
+- **FieldRepository** -- CRUD on the `fields` table (config stored as JSONB)
+
+## Database schema
+
+### flows
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `UUID` | PK |
+| `name` | `VARCHAR(128)` | |
+| `description` | `TEXT` | |
+| `created_at` / `updated_at` | `TIMESTAMP` | auto-set |
+
+### steps
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `UUID` | PK |
+| `flow_id` | `UUID` | FK -> flows (CASCADE) |
+| `title` | `VARCHAR(128)` | |
+| `description` | `TEXT` | |
+| `rank` | `VARCHAR(255)` | LexoRank string, indexed with `flow_id` |
+
+### fields
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `UUID` | PK |
+| `steps_id` | `UUID` | FK -> steps (CASCADE) |
+| `key` | `VARCHAR(32)` | |
+| `label` | `VARCHAR(255)` | |
+| `description` | `TEXT` | |
+| `config` | `JSONB` | Typed field configuration |
+| `rank` | `VARCHAR(255)` | LexoRank string, indexed with `steps_id` |
+
+## Migrations
+
+Migrations are managed with SQLx and located in `migrations/`. They include:
+
+1. `create_flows_table` -- base flows table
+2. `create_steps_table` -- steps with FK to flows + rank index
+3. `create_fields_table` -- fields with FK to steps + JSONB config + rank index
+4. `create_estimators_table` -- estimator definitions
+5. `create_estimator_variables_table` -- estimator variables
+
+Run migrations:
+
+```bash
+sqlx migrate run --source libs/ferrisquote-postgres/migrations
+```
+
+## Usage
+
+```rust
+let pool = PgPoolOptions::new()
+    .max_connections(5)
+    .connect(&database_url)
+    .await?;
+
+let repo = PostgresFlowRepository::new(pool);
+// repo implements FlowRepository + StepRepository + FieldRepository
+```


### PR DESCRIPTION
This pull request adds comprehensive documentation for the structure and architecture of the FerrisQuote monorepo, including both application and library crates. The new README files clarify the responsibilities, dependencies, and design decisions for each component, making it easier for developers to understand and contribute to the project.

**Monorepo and application structure:**

* Added `apps/README.md` to describe the purpose, stack, and relationships of the main applications (`ferrisquote-api` and `ferrisquote-webapp`), along with quick start instructions and a visual overview of dependencies.

**Shared libraries documentation:**

* Added `libs/README.md` to outline the roles of shared crates (`ferrisquote-domain`, `ferrisquote-auth`, `ferrisquote-postgres`), their dependencies, and a diagram of the overall architecture.

**Domain logic and architecture:**

* Added `libs/ferrisquote-domain/README.md` to document the core business logic crate, detailing domain entities, service and repository traits, the use of LexoRank for ordering, and key design decisions such as partial updates and avoidance of the `async-trait` macro.

**Authentication library:**

* Added `libs/ferrisquote-auth/README.md` to explain the OIDC/JWT authentication library, including its architecture (ports and adapters), main entities, validation process, and test coverage.

**PostgreSQL persistence layer:**

* Added `libs/ferrisquote-postgres/README.md` describing the implementation of repository traits using SQLx, the database schema, migration process, and usage examples for integrating with the domain layer.