### PR TITLE
feat(postgres): add submission evaluation and Postgres estimator repository

### DIFF
--- a/libs/ferrisquote-domain/src/domain/estimator/entities.rs
+++ b/libs/ferrisquote-domain/src/domain/estimator/entities.rs
@@ -1,3 +1,4 @@
 pub mod estimator;
 pub mod ids;
+pub mod submission;
 pub mod variable;

--- a/libs/ferrisquote-domain/src/domain/estimator/entities/submission.rs
+++ b/libs/ferrisquote-domain/src/domain/estimator/entities/submission.rs
@@ -1,0 +1,10 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SubmissionData {
+    pub field_values: HashMap<String, f64>,
+    pub iteration_values: HashMap<String, Vec<f64>>,
+    pub iteration_counts: HashMap<String, usize>,
+}

--- a/libs/ferrisquote-domain/src/domain/estimator/ports.rs
+++ b/libs/ferrisquote-domain/src/domain/estimator/ports.rs
@@ -5,6 +5,7 @@ use crate::domain::{error::DomainError, flows::entities::ids::FlowId};
 use super::entities::{
     estimator::Estimator,
     ids::{EstimatorId, EstimatorVariableId},
+    submission::SubmissionData,
     variable::EstimatorVariable,
 };
 
@@ -112,18 +113,15 @@ pub trait EstimatorService: Send + Sync {
 
     // --- Evaluation ---
 
-    /// Evaluate all variables of an estimator given a map of field values.
-    ///
-    /// `field_values` maps `field_key` → numeric value (e.g. `"surface"` → `50.0`).
-    ///
-    /// Returns a map of `variable_name` → computed value.
-    ///
-    /// Variables are resolved in dependency order.  A `DomainError::ValidationError`
-    /// is returned if a circular dependency is detected or if an expression cannot
-    /// be evaluated.
     fn evaluate(
         &self,
         estimator_id: EstimatorId,
         field_values: HashMap<String, f64>,
+    ) -> impl Future<Output = Result<HashMap<String, f64>, DomainError>> + Send;
+
+    fn evaluate_submission(
+        &self,
+        estimator_id: EstimatorId,
+        data: SubmissionData,
     ) -> impl Future<Output = Result<HashMap<String, f64>, DomainError>> + Send;
 }

--- a/libs/ferrisquote-domain/src/domain/estimator/services.rs
+++ b/libs/ferrisquote-domain/src/domain/estimator/services.rs
@@ -6,6 +6,7 @@ use super::{
     entities::{
         estimator::Estimator,
         ids::{EstimatorId, EstimatorVariableId},
+        submission::SubmissionData,
         variable::EstimatorVariable,
     },
     ports::{EstimatorRepository, EstimatorService},
@@ -90,6 +91,15 @@ where
         let estimator = self.repo.get_estimator(estimator_id).await?;
         evaluate_estimator(&estimator, &field_values)
     }
+
+    async fn evaluate_submission(
+        &self,
+        estimator_id: EstimatorId,
+        data: SubmissionData,
+    ) -> Result<HashMap<String, f64>, DomainError> {
+        let estimator = self.repo.get_estimator(estimator_id).await?;
+        evaluate_estimator_with_submission(&estimator, &data)
+    }
 }
 
 // ============================================================================
@@ -135,6 +145,122 @@ pub fn evaluate_estimator(
     }
 
     Ok(results)
+}
+
+pub fn evaluate_estimator_with_submission(
+    estimator: &Estimator,
+    data: &SubmissionData,
+) -> Result<HashMap<String, f64>, DomainError> {
+    let order = topological_sort(&estimator.variables)?;
+
+    use evalexpr::ContextWithMutableVariables;
+    let mut ctx = evalexpr::HashMapContext::<evalexpr::DefaultNumericTypes>::new();
+
+    for (key, &value) in &data.field_values {
+        ctx.set_value(key.clone(), evalexpr::Value::Float(value))
+            .map_err(|e| DomainError::internal(e.to_string()))?;
+    }
+
+    let var_by_id: HashMap<EstimatorVariableId, &EstimatorVariable> =
+        estimator.variables.iter().map(|v| (v.id, v)).collect();
+
+    let mut results = HashMap::new();
+
+    for id in order {
+        let var = var_by_id[&id];
+        let expr = resolve_aggregations(&var.expression, data)?;
+        let expr = prepare_expression(&expr);
+
+        let value = evalexpr::eval_float_with_context(&expr, &ctx).map_err(|e| {
+            DomainError::validation(format!(
+                "Failed to evaluate variable '{}': {}",
+                var.name, e
+            ))
+        })?;
+
+        ctx.set_value(var.name.clone(), evalexpr::Value::Float(value))
+            .map_err(|e| DomainError::internal(e.to_string()))?;
+
+        results.insert(var.name.clone(), value);
+    }
+
+    Ok(results)
+}
+
+fn resolve_aggregations(expr: &str, data: &SubmissionData) -> Result<String, DomainError> {
+    let mut result = expr.to_string();
+
+    while let Some(pos) = find_aggregation(&result) {
+        let (func_name, arg, start, end) = pos;
+        let replacement = match func_name.as_str() {
+            "SUM" => {
+                let values = data
+                    .iteration_values
+                    .get(&arg)
+                    .ok_or_else(|| {
+                        DomainError::validation(format!(
+                            "SUM references unknown repeatable field '{arg}'"
+                        ))
+                    })?;
+                values.iter().sum::<f64>()
+            }
+            "AVG" => {
+                let values = data
+                    .iteration_values
+                    .get(&arg)
+                    .ok_or_else(|| {
+                        DomainError::validation(format!(
+                            "AVG references unknown repeatable field '{arg}'"
+                        ))
+                    })?;
+                if values.is_empty() {
+                    0.0
+                } else {
+                    values.iter().sum::<f64>() / values.len() as f64
+                }
+            }
+            "COUNT_ITER" => {
+                let count = data
+                    .iteration_counts
+                    .get(&arg)
+                    .ok_or_else(|| {
+                        DomainError::validation(format!(
+                            "COUNT_ITER references unknown step '{arg}'"
+                        ))
+                    })?;
+                *count as f64
+            }
+            _ => {
+                return Err(DomainError::validation(format!(
+                    "Unknown aggregation function '{func_name}'"
+                )));
+            }
+        };
+        let formatted = format_float(replacement);
+        result = format!("{}{formatted}{}", &result[..start], &result[end..]);
+    }
+
+    Ok(result)
+}
+
+fn format_float(v: f64) -> String {
+    let s = v.to_string();
+    if s.contains('.') { s } else { format!("{s}.0") }
+}
+
+fn find_aggregation(expr: &str) -> Option<(String, String, usize, usize)> {
+    for func in &["SUM", "AVG", "COUNT_ITER"] {
+        if let Some(start) = expr.find(&format!("{func}(")) {
+            let after_paren = start + func.len() + 1;
+            if let Some(close) = expr[after_paren..].find(')') {
+                let end = after_paren + close + 1;
+                let inner = expr[after_paren..after_paren + close].trim();
+                let arg = inner.strip_prefix('@').unwrap_or(inner).to_string();
+                return Some((func.to_string(), arg, start, end));
+            }
+        }
+    }
+    None
 }
 
 /// Strip `@` prefixes so `@surface * @prix` becomes `surface * prix`,
@@ -267,7 +393,6 @@ mod tests {
 
     #[test]
     fn test_variable_dependency_chain() {
-        // ht depends on surface and prix, ttc depends on ht
         let estimator = make_estimator(vec![
             make_var("ht", "@surface * @prix"),
             make_var("ttc", "@ht * 1.2"),
@@ -293,5 +418,128 @@ mod tests {
         let estimator = make_estimator(vec![make_var("tva", "0.2")]);
         let result = evaluate_estimator(&estimator, &HashMap::new()).unwrap();
         assert_eq!(result["tva"], 0.2);
+    }
+
+    // ========================================================================
+    // Aggregation tests
+    // ========================================================================
+
+    #[test]
+    fn test_sum_with_multiple_iterations() {
+        let estimator = make_estimator(vec![make_var("total", "SUM(@surface) * @prix")]);
+        let data = SubmissionData {
+            field_values: HashMap::from([("prix".to_string(), 10.0)]),
+            iteration_values: HashMap::from([(
+                "surface".to_string(),
+                vec![5.0, 10.0, 15.0],
+            )]),
+            iteration_counts: HashMap::new(),
+        };
+        let result = evaluate_estimator_with_submission(&estimator, &data).unwrap();
+        assert_eq!(result["total"], 300.0);
+    }
+
+    #[test]
+    fn test_sum_with_zero_iterations() {
+        let estimator = make_estimator(vec![make_var("total", "SUM(@surface)")]);
+        let data = SubmissionData {
+            field_values: HashMap::new(),
+            iteration_values: HashMap::from([("surface".to_string(), vec![])]),
+            iteration_counts: HashMap::new(),
+        };
+        let result = evaluate_estimator_with_submission(&estimator, &data).unwrap();
+        assert_eq!(result["total"], 0.0);
+    }
+
+    #[test]
+    fn test_sum_with_single_iteration() {
+        let estimator = make_estimator(vec![make_var("total", "SUM(@surface)")]);
+        let data = SubmissionData {
+            field_values: HashMap::new(),
+            iteration_values: HashMap::from([("surface".to_string(), vec![42.0])]),
+            iteration_counts: HashMap::new(),
+        };
+        let result = evaluate_estimator_with_submission(&estimator, &data).unwrap();
+        assert_eq!(result["total"], 42.0);
+    }
+
+    #[test]
+    fn test_avg_with_multiple_iterations() {
+        let estimator = make_estimator(vec![make_var("avg_surface", "AVG(@surface)")]);
+        let data = SubmissionData {
+            field_values: HashMap::new(),
+            iteration_values: HashMap::from([(
+                "surface".to_string(),
+                vec![10.0, 20.0, 30.0],
+            )]),
+            iteration_counts: HashMap::new(),
+        };
+        let result = evaluate_estimator_with_submission(&estimator, &data).unwrap();
+        assert_eq!(result["avg_surface"], 20.0);
+    }
+
+    #[test]
+    fn test_avg_with_zero_iterations() {
+        let estimator = make_estimator(vec![make_var("avg_surface", "AVG(@surface)")]);
+        let data = SubmissionData {
+            field_values: HashMap::new(),
+            iteration_values: HashMap::from([("surface".to_string(), vec![])]),
+            iteration_counts: HashMap::new(),
+        };
+        let result = evaluate_estimator_with_submission(&estimator, &data).unwrap();
+        assert_eq!(result["avg_surface"], 0.0);
+    }
+
+    #[test]
+    fn test_count_iterations() {
+        let estimator = make_estimator(vec![
+            make_var("count", "COUNT_ITER(@rooms)"),
+            make_var("cost", "@count * 100.0"),
+        ]);
+        let data = SubmissionData {
+            field_values: HashMap::new(),
+            iteration_values: HashMap::new(),
+            iteration_counts: HashMap::from([("rooms".to_string(), 5)]),
+        };
+        let result = evaluate_estimator_with_submission(&estimator, &data).unwrap();
+        assert_eq!(result["count"], 5.0);
+        assert_eq!(result["cost"], 500.0);
+    }
+
+    #[test]
+    fn test_mixed_static_and_aggregated() {
+        let estimator = make_estimator(vec![
+            make_var("total_surface", "SUM(@surface)"),
+            make_var("ht", "@total_surface * @prix_unitaire"),
+            make_var("ttc", "@ht * 1.2"),
+        ]);
+        let data = SubmissionData {
+            field_values: HashMap::from([("prix_unitaire".to_string(), 50.0)]),
+            iteration_values: HashMap::from([(
+                "surface".to_string(),
+                vec![10.0, 20.0, 30.0],
+            )]),
+            iteration_counts: HashMap::new(),
+        };
+        let result = evaluate_estimator_with_submission(&estimator, &data).unwrap();
+        assert_eq!(result["total_surface"], 60.0);
+        assert_eq!(result["ht"], 3000.0);
+        assert!((result["ttc"] - 3600.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_sum_unknown_field_errors() {
+        let estimator = make_estimator(vec![make_var("total", "SUM(@unknown)")]);
+        let data = SubmissionData::default();
+        let result = evaluate_estimator_with_submission(&estimator, &data);
+        assert!(matches!(result, Err(DomainError::ValidationError { .. })));
+    }
+
+    #[test]
+    fn test_count_iter_unknown_step_errors() {
+        let estimator = make_estimator(vec![make_var("n", "COUNT_ITER(@unknown_step)")]);
+        let data = SubmissionData::default();
+        let result = evaluate_estimator_with_submission(&estimator, &data);
+        assert!(matches!(result, Err(DomainError::ValidationError { .. })));
     }
 }

--- a/libs/ferrisquote-postgres/src/lib.rs
+++ b/libs/ferrisquote-postgres/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod repositories;
 
+pub use repositories::PostgresEstimatorRepository;
 pub use repositories::PostgresFlowRepository;

--- a/libs/ferrisquote-postgres/src/repositories/estimator_repository.rs
+++ b/libs/ferrisquote-postgres/src/repositories/estimator_repository.rs
@@ -1,0 +1,253 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ferrisquote_domain::domain::{
+    error::DomainError,
+    estimator::{
+        entities::{
+            estimator::Estimator,
+            ids::{EstimatorId, EstimatorVariableId},
+            variable::EstimatorVariable,
+        },
+        ports::EstimatorRepository,
+    },
+    flows::entities::ids::FlowId,
+};
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct PostgresEstimatorRepository {
+    pool: Arc<PgPool>,
+}
+
+impl PostgresEstimatorRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool: Arc::new(pool),
+        }
+    }
+
+    pub fn with_pool(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+}
+
+async fn load_variables_for_estimators(
+    pool: &PgPool,
+    estimator_ids: &[Uuid],
+) -> Result<HashMap<Uuid, Vec<EstimatorVariable>>, DomainError> {
+    if estimator_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = sqlx::query(
+        "SELECT id, estimator_id, name, expression, description \
+         FROM estimator_variables \
+         WHERE estimator_id = ANY($1) \
+         ORDER BY estimator_id, rank",
+    )
+    .bind(estimator_ids)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| DomainError::repository(e.to_string()))?;
+
+    let mut map: HashMap<Uuid, Vec<EstimatorVariable>> = HashMap::new();
+    for row in rows {
+        let var = EstimatorVariable::with_id(
+            EstimatorVariableId::from_uuid(row.get("id")),
+            row.get("name"),
+            row.get("expression"),
+            row.get::<Option<String>, _>("description").unwrap_or_default(),
+        );
+        map.entry(row.get("estimator_id")).or_default().push(var);
+    }
+
+    Ok(map)
+}
+
+impl EstimatorRepository for PostgresEstimatorRepository {
+    async fn create_estimator(&self, estimator: Estimator) -> Result<Estimator, DomainError> {
+        sqlx::query(
+            "INSERT INTO estimators (id, flow_id, name, created_at, updated_at) \
+             VALUES ($1, $2, $3, NOW(), NOW())",
+        )
+        .bind(estimator.id.into_uuid())
+        .bind(estimator.flow_id.into_uuid())
+        .bind(&estimator.name)
+        .execute(&*self.pool)
+        .await
+        .map_err(|e| DomainError::repository(e.to_string()))?;
+
+        Ok(estimator)
+    }
+
+    async fn get_estimator(&self, id: EstimatorId) -> Result<Estimator, DomainError> {
+        let row = sqlx::query(
+            "SELECT id, flow_id, name FROM estimators WHERE id = $1",
+        )
+        .bind(id.into_uuid())
+        .fetch_optional(&*self.pool)
+        .await
+        .map_err(|e| DomainError::repository(e.to_string()))?
+        .ok_or_else(|| DomainError::not_found("Estimator", id.to_string()))?;
+
+        let est_uuid: Uuid = row.get("id");
+        let mut vars_map = load_variables_for_estimators(&self.pool, &[est_uuid]).await?;
+        let variables = vars_map.remove(&est_uuid).unwrap_or_default();
+
+        Ok(Estimator::with_variables(
+            EstimatorId::from_uuid(est_uuid),
+            FlowId::from_uuid(row.get("flow_id")),
+            row.get("name"),
+            variables,
+        ))
+    }
+
+    async fn list_estimators_for_flow(
+        &self,
+        flow_id: FlowId,
+    ) -> Result<Vec<Estimator>, DomainError> {
+        let rows = sqlx::query(
+            "SELECT id, flow_id, name FROM estimators \
+             WHERE flow_id = $1 \
+             ORDER BY created_at",
+        )
+        .bind(flow_id.into_uuid())
+        .fetch_all(&*self.pool)
+        .await
+        .map_err(|e| DomainError::repository(e.to_string()))?;
+
+        let est_ids: Vec<Uuid> = rows.iter().map(|r| r.get("id")).collect();
+        let mut vars_map = load_variables_for_estimators(&self.pool, &est_ids).await?;
+
+        let estimators = rows
+            .iter()
+            .map(|row| {
+                let eid: Uuid = row.get("id");
+                let variables = vars_map.remove(&eid).unwrap_or_default();
+                Estimator::with_variables(
+                    EstimatorId::from_uuid(eid),
+                    FlowId::from_uuid(row.get("flow_id")),
+                    row.get("name"),
+                    variables,
+                )
+            })
+            .collect();
+
+        Ok(estimators)
+    }
+
+    async fn update_estimator(
+        &self,
+        id: EstimatorId,
+        name: Option<String>,
+    ) -> Result<Estimator, DomainError> {
+        let row = sqlx::query(
+            "UPDATE estimators \
+             SET name = COALESCE($2, name), \
+                 updated_at = NOW() \
+             WHERE id = $1 \
+             RETURNING id, flow_id, name",
+        )
+        .bind(id.into_uuid())
+        .bind(name)
+        .fetch_optional(&*self.pool)
+        .await
+        .map_err(|e| DomainError::repository(e.to_string()))?
+        .ok_or_else(|| DomainError::not_found("Estimator", id.to_string()))?;
+
+        let est_uuid: Uuid = row.get("id");
+        let mut vars_map = load_variables_for_estimators(&self.pool, &[est_uuid]).await?;
+        let variables = vars_map.remove(&est_uuid).unwrap_or_default();
+
+        Ok(Estimator::with_variables(
+            EstimatorId::from_uuid(est_uuid),
+            FlowId::from_uuid(row.get("flow_id")),
+            row.get("name"),
+            variables,
+        ))
+    }
+
+    async fn delete_estimator(&self, id: EstimatorId) -> Result<(), DomainError> {
+        let result = sqlx::query("DELETE FROM estimators WHERE id = $1")
+            .bind(id.into_uuid())
+            .execute(&*self.pool)
+            .await
+            .map_err(|e| DomainError::repository(e.to_string()))?;
+
+        if result.rows_affected() == 0 {
+            return Err(DomainError::not_found("Estimator", id.to_string()));
+        }
+
+        Ok(())
+    }
+
+    async fn add_variable(
+        &self,
+        estimator_id: EstimatorId,
+        variable: EstimatorVariable,
+    ) -> Result<EstimatorVariable, DomainError> {
+        sqlx::query(
+            "INSERT INTO estimator_variables (id, estimator_id, name, expression, description, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, NOW(), NOW())",
+        )
+        .bind(variable.id.into_uuid())
+        .bind(estimator_id.into_uuid())
+        .bind(&variable.name)
+        .bind(&variable.expression)
+        .bind(&variable.description)
+        .execute(&*self.pool)
+        .await
+        .map_err(|e| DomainError::repository(e.to_string()))?;
+
+        Ok(variable)
+    }
+
+    async fn update_variable(
+        &self,
+        id: EstimatorVariableId,
+        name: Option<String>,
+        expression: Option<String>,
+        description: Option<String>,
+    ) -> Result<EstimatorVariable, DomainError> {
+        let row = sqlx::query(
+            "UPDATE estimator_variables \
+             SET name = COALESCE($2, name), \
+                 expression = COALESCE($3, expression), \
+                 description = COALESCE($4, description), \
+                 updated_at = NOW() \
+             WHERE id = $1 \
+             RETURNING id, name, expression, description",
+        )
+        .bind(id.into_uuid())
+        .bind(name)
+        .bind(expression)
+        .bind(description)
+        .fetch_optional(&*self.pool)
+        .await
+        .map_err(|e| DomainError::repository(e.to_string()))?
+        .ok_or_else(|| DomainError::not_found("EstimatorVariable", id.to_string()))?;
+
+        Ok(EstimatorVariable::with_id(
+            EstimatorVariableId::from_uuid(row.get("id")),
+            row.get("name"),
+            row.get("expression"),
+            row.get::<Option<String>, _>("description").unwrap_or_default(),
+        ))
+    }
+
+    async fn remove_variable(&self, id: EstimatorVariableId) -> Result<(), DomainError> {
+        let result = sqlx::query("DELETE FROM estimator_variables WHERE id = $1")
+            .bind(id.into_uuid())
+            .execute(&*self.pool)
+            .await
+            .map_err(|e| DomainError::repository(e.to_string()))?;
+
+        if result.rows_affected() == 0 {
+            return Err(DomainError::not_found("EstimatorVariable", id.to_string()));
+        }
+
+        Ok(())
+    }
+}

--- a/libs/ferrisquote-postgres/src/repositories/mod.rs
+++ b/libs/ferrisquote-postgres/src/repositories/mod.rs
@@ -1,3 +1,5 @@
+pub mod estimator_repository;
 pub mod flow_repository;
 
+pub use estimator_repository::PostgresEstimatorRepository;
 pub use flow_repository::PostgresFlowRepository;


### PR DESCRIPTION
This pull request introduces aggregation support in estimator evaluations and adds a new Postgres-backed estimator repository. The main changes include the implementation of aggregation functions such as `SUM`, `AVG`, and `COUNT_ITER` in estimator expressions, a new `SubmissionData` structure to support richer evaluation inputs, and comprehensive tests for these features. Additionally, a new `PostgresEstimatorRepository` is provided for persistence, supporting all CRUD operations for estimators and their variables.

**Aggregation Support and Evaluation Enhancements**
- Introduced the `SubmissionData` struct to represent richer estimator input, including support for iteration values and counts.
- Added a new `evaluate_submission` method to the `EstimatorService` trait and its implementation, allowing evaluation of estimators with aggregation functions over repeated fields. [[1]](diffhunk://#diff-e403aa4ae69250e87b146704cb3fc60b888b86cf1c0566afc3ef066b21fb0d61L115-R126) [[2]](diffhunk://#diff-8e450a652b3780d217575b27e028469ec05908d4d12dafa85ceb53e9c3acd606R94-R102)
- Implemented parsing and evaluation logic for aggregation functions (`SUM`, `AVG`, `COUNT_ITER`) within estimator variable expressions, enabling calculations over lists of values and iteration counts.

**Testing**
- Added comprehensive tests for aggregation scenarios, including sums, averages, counts, mixed static and aggregated variables, and error handling for unknown fields or steps.

**Persistence Layer**
- Implemented `PostgresEstimatorRepository` with full CRUD support for estimators and their variables, including batch loading of variables for efficiency. [[1]](diffhunk://#diff-ed65effe5941410d30bb440ef6946379c838ac6db1a423da6aae4ef5ebad61edR1-R253) [[2]](diffhunk://#diff-8f585f1f1f6f7b150c1e15bfe2e212e896f583debc12d21ed076c499d305df89R3) [[3]](diffhunk://#diff-8251d7a153436b9384b3cafb983acbc23e85812c3486906b0dc4f5a869164e18R1-R4)

**Module Organization**
- Registered the new `submission` module and repository exports for use throughout the codebase. [[1]](diffhunk://#diff-dad648639c626e648816a56c96eacb8bc77a933e5d5d30207bec90fd0200eafaR3) [[2]](diffhunk://#diff-8f585f1f1f6f7b150c1e15bfe2e212e896f583debc12d21ed076c499d305df89R3) [[3]](diffhunk://#diff-8251d7a153436b9384b3cafb983acbc23e85812c3486906b0dc4f5a869164e18R1-R4)