### PR TITLE
60 feat endpoints api crud pour les estimateurs

### DIFF
--- a/apps/ferrisquote-api/src/dto/estimators.rs
+++ b/apps/ferrisquote-api/src/dto/estimators.rs
@@ -1,0 +1,84 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+use validator::Validate;
+
+// ============================================================================
+// Request DTOs
+// ============================================================================
+
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+pub struct CreateEstimatorRequest {
+    #[validate(length(min = 1, max = 255))]
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+pub struct UpdateEstimatorRequest {
+    #[validate(length(min = 1, max = 255))]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+pub struct CreateVariableRequest {
+    #[validate(length(min = 1, max = 255))]
+    pub name: String,
+    #[validate(length(min = 1))]
+    pub expression: String,
+    #[validate(length(max = 1000))]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+pub struct UpdateVariableRequest {
+    #[validate(length(min = 1, max = 255))]
+    pub name: Option<String>,
+    #[validate(length(min = 1))]
+    pub expression: Option<String>,
+    #[validate(length(max = 1000))]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct EvaluateRequest {
+    pub field_values: HashMap<String, f64>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct EvaluateSubmissionRequest {
+    pub field_values: HashMap<String, f64>,
+    pub iteration_values: HashMap<String, Vec<f64>>,
+    pub iteration_counts: HashMap<String, usize>,
+}
+
+// ============================================================================
+// Response DTOs
+// ============================================================================
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct EstimatorResponse {
+    pub id: Uuid,
+    pub flow_id: Uuid,
+    pub name: String,
+    pub variables: Vec<VariableResponse>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct VariableResponse {
+    pub id: Uuid,
+    pub name: String,
+    pub expression: String,
+    pub description: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct EstimatorListResponse {
+    pub estimators: Vec<EstimatorResponse>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct EvaluateResponse {
+    pub results: HashMap<String, f64>,
+}

--- a/apps/ferrisquote-api/src/dto/mod.rs
+++ b/apps/ferrisquote-api/src/dto/mod.rs
@@ -1,6 +1,12 @@
+pub mod estimators;
 pub mod flows;
 
 // Re-export commonly used DTOs
+pub use estimators::{
+    CreateEstimatorRequest, CreateVariableRequest, EstimatorListResponse, EstimatorResponse,
+    EvaluateRequest, EvaluateResponse, EvaluateSubmissionRequest, UpdateEstimatorRequest,
+    UpdateVariableRequest, VariableResponse,
+};
 pub use flows::{
     ApiResponse, CreateFieldRequest, CreateFlowRequest, CreateStepRequest, FieldConfigDto,
     FieldResponse, FlowListResponse, FlowResponse, FlowSummaryResponse, MessageResponse,

--- a/apps/ferrisquote-api/src/handlers/estimator_handlers.rs
+++ b/apps/ferrisquote-api/src/handlers/estimator_handlers.rs
@@ -1,0 +1,329 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use ferrisquote_domain::domain::{
+    estimator::{
+        entities::{ids::{EstimatorId, EstimatorVariableId}, submission::SubmissionData},
+        ports::EstimatorService,
+    },
+    flows::ports::{FieldService, FlowService, StepService},
+};
+use ferrisquote_domain::FlowId;
+use validator::Validate;
+
+use crate::{
+    dto::{
+        ApiResponse, CreateEstimatorRequest, CreateVariableRequest, EstimatorListResponse,
+        EstimatorResponse, EvaluateRequest, EvaluateResponse, EvaluateSubmissionRequest,
+        MessageResponse, UpdateEstimatorRequest, UpdateVariableRequest, VariableResponse,
+    },
+    error::ApiResult,
+    state::AppState,
+};
+
+fn map_estimator(e: ferrisquote_domain::Estimator) -> EstimatorResponse {
+    EstimatorResponse {
+        id: e.id.into_uuid(),
+        flow_id: e.flow_id.into_uuid(),
+        name: e.name,
+        variables: e.variables.into_iter().map(map_variable).collect(),
+    }
+}
+
+fn map_variable(v: ferrisquote_domain::EstimatorVariable) -> VariableResponse {
+    VariableResponse {
+        id: v.id.into_uuid(),
+        name: v.name,
+        expression: v.expression,
+        description: v.description,
+    }
+}
+
+// ============================================================================
+// Estimator CRUD
+// ============================================================================
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/flows/{flow_id}/estimators",
+    params(("flow_id" = String, Path, description = "Flow UUID")),
+    request_body = CreateEstimatorRequest,
+    responses(
+        (status = 201, description = "Estimator created", body = EstimatorResponse),
+        (status = 400, description = "Validation error"),
+    ),
+    tag = "estimators"
+)]
+pub async fn create_estimator<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(flow_id): Path<String>,
+    Json(request): Json<CreateEstimatorRequest>,
+) -> ApiResult<(StatusCode, Json<ApiResponse<EstimatorResponse>>)> {
+    request.validate()?;
+
+    let flow_id = FlowId::from_uuid(uuid::Uuid::parse_str(&flow_id)?);
+    let estimator = state
+        .estimator_service
+        .create_estimator(flow_id, request.name)
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ApiResponse::success(map_estimator(estimator))),
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/flows/{flow_id}/estimators",
+    params(("flow_id" = String, Path, description = "Flow UUID")),
+    responses(
+        (status = 200, description = "List of estimators", body = EstimatorListResponse),
+    ),
+    tag = "estimators"
+)]
+pub async fn list_estimators<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(flow_id): Path<String>,
+) -> ApiResult<Json<ApiResponse<EstimatorListResponse>>> {
+    let flow_id = FlowId::from_uuid(uuid::Uuid::parse_str(&flow_id)?);
+    let estimators = state
+        .estimator_service
+        .list_estimators_for_flow(flow_id)
+        .await?;
+
+    let response = EstimatorListResponse {
+        estimators: estimators.into_iter().map(map_estimator).collect(),
+    };
+
+    Ok(Json(ApiResponse::success(response)))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/estimators/{estimator_id}",
+    params(("estimator_id" = String, Path, description = "Estimator UUID")),
+    responses(
+        (status = 200, description = "Estimator found", body = EstimatorResponse),
+        (status = 404, description = "Estimator not found"),
+    ),
+    tag = "estimators"
+)]
+pub async fn get_estimator<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(estimator_id): Path<String>,
+) -> ApiResult<Json<ApiResponse<EstimatorResponse>>> {
+    let id = EstimatorId::from_uuid(uuid::Uuid::parse_str(&estimator_id)?);
+    let estimator = state.estimator_service.get_estimator(id).await?;
+
+    Ok(Json(ApiResponse::success(map_estimator(estimator))))
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/v1/estimators/{estimator_id}",
+    params(("estimator_id" = String, Path, description = "Estimator UUID")),
+    request_body = UpdateEstimatorRequest,
+    responses(
+        (status = 200, description = "Estimator updated", body = EstimatorResponse),
+        (status = 400, description = "Validation error"),
+        (status = 404, description = "Estimator not found"),
+    ),
+    tag = "estimators"
+)]
+pub async fn update_estimator<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(estimator_id): Path<String>,
+    Json(request): Json<UpdateEstimatorRequest>,
+) -> ApiResult<Json<ApiResponse<EstimatorResponse>>> {
+    request.validate()?;
+
+    let id = EstimatorId::from_uuid(uuid::Uuid::parse_str(&estimator_id)?);
+    let estimator = state
+        .estimator_service
+        .update_estimator(id, request.name)
+        .await?;
+
+    Ok(Json(ApiResponse::success(map_estimator(estimator))))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/v1/estimators/{estimator_id}",
+    params(("estimator_id" = String, Path, description = "Estimator UUID")),
+    responses(
+        (status = 200, description = "Estimator deleted", body = MessageResponse),
+        (status = 404, description = "Estimator not found"),
+    ),
+    tag = "estimators"
+)]
+pub async fn delete_estimator<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(estimator_id): Path<String>,
+) -> ApiResult<(StatusCode, Json<ApiResponse<MessageResponse>>)> {
+    let id = EstimatorId::from_uuid(uuid::Uuid::parse_str(&estimator_id)?);
+    state.estimator_service.delete_estimator(id).await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(ApiResponse::success(MessageResponse::new(
+            "Estimator deleted successfully",
+        ))),
+    ))
+}
+
+// ============================================================================
+// Variable CRUD
+// ============================================================================
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/estimators/{estimator_id}/variables",
+    params(("estimator_id" = String, Path, description = "Estimator UUID")),
+    request_body = CreateVariableRequest,
+    responses(
+        (status = 201, description = "Variable created", body = VariableResponse),
+        (status = 400, description = "Validation error"),
+        (status = 404, description = "Estimator not found"),
+    ),
+    tag = "estimator_variables"
+)]
+pub async fn add_variable<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(estimator_id): Path<String>,
+    Json(request): Json<CreateVariableRequest>,
+) -> ApiResult<(StatusCode, Json<ApiResponse<VariableResponse>>)> {
+    request.validate()?;
+
+    let id = EstimatorId::from_uuid(uuid::Uuid::parse_str(&estimator_id)?);
+    let variable = state
+        .estimator_service
+        .add_variable(
+            id,
+            request.name,
+            request.expression,
+            request.description.unwrap_or_default(),
+        )
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ApiResponse::success(map_variable(variable))),
+    ))
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/v1/variables/{variable_id}",
+    params(("variable_id" = String, Path, description = "Variable UUID")),
+    request_body = UpdateVariableRequest,
+    responses(
+        (status = 200, description = "Variable updated", body = VariableResponse),
+        (status = 400, description = "Validation error"),
+        (status = 404, description = "Variable not found"),
+    ),
+    tag = "estimator_variables"
+)]
+pub async fn update_variable<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(variable_id): Path<String>,
+    Json(request): Json<UpdateVariableRequest>,
+) -> ApiResult<Json<ApiResponse<VariableResponse>>> {
+    request.validate()?;
+
+    let id = EstimatorVariableId::from_uuid(uuid::Uuid::parse_str(&variable_id)?);
+    let variable = state
+        .estimator_service
+        .update_variable(id, request.name, request.expression, request.description)
+        .await?;
+
+    Ok(Json(ApiResponse::success(map_variable(variable))))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/v1/variables/{variable_id}",
+    params(("variable_id" = String, Path, description = "Variable UUID")),
+    responses(
+        (status = 200, description = "Variable deleted", body = MessageResponse),
+        (status = 404, description = "Variable not found"),
+    ),
+    tag = "estimator_variables"
+)]
+pub async fn remove_variable<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(variable_id): Path<String>,
+) -> ApiResult<(StatusCode, Json<ApiResponse<MessageResponse>>)> {
+    let id = EstimatorVariableId::from_uuid(uuid::Uuid::parse_str(&variable_id)?);
+    state.estimator_service.remove_variable(id).await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(ApiResponse::success(MessageResponse::new(
+            "Variable deleted successfully",
+        ))),
+    ))
+}
+
+// ============================================================================
+// Evaluation
+// ============================================================================
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/estimators/{estimator_id}/evaluate",
+    params(("estimator_id" = String, Path, description = "Estimator UUID")),
+    request_body = EvaluateRequest,
+    responses(
+        (status = 200, description = "Evaluation result", body = EvaluateResponse),
+        (status = 400, description = "Evaluation error"),
+        (status = 404, description = "Estimator not found"),
+    ),
+    tag = "estimators"
+)]
+pub async fn evaluate<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(estimator_id): Path<String>,
+    Json(request): Json<EvaluateRequest>,
+) -> ApiResult<Json<ApiResponse<EvaluateResponse>>> {
+    let id = EstimatorId::from_uuid(uuid::Uuid::parse_str(&estimator_id)?);
+    let results = state
+        .estimator_service
+        .evaluate(id, request.field_values)
+        .await?;
+
+    Ok(Json(ApiResponse::success(EvaluateResponse { results })))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/estimators/{estimator_id}/evaluate-submission",
+    params(("estimator_id" = String, Path, description = "Estimator UUID")),
+    request_body = EvaluateSubmissionRequest,
+    responses(
+        (status = 200, description = "Evaluation result", body = EvaluateResponse),
+        (status = 400, description = "Evaluation error"),
+        (status = 404, description = "Estimator not found"),
+    ),
+    tag = "estimators"
+)]
+pub async fn evaluate_submission<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
+    Path(estimator_id): Path<String>,
+    Json(request): Json<EvaluateSubmissionRequest>,
+) -> ApiResult<Json<ApiResponse<EvaluateResponse>>> {
+    let id = EstimatorId::from_uuid(uuid::Uuid::parse_str(&estimator_id)?);
+    let data = SubmissionData {
+        field_values: request.field_values,
+        iteration_values: request.iteration_values,
+        iteration_counts: request.iteration_counts,
+    };
+    let results = state
+        .estimator_service
+        .evaluate_submission(id, data)
+        .await?;
+
+    Ok(Json(ApiResponse::success(EvaluateResponse { results })))
+}

--- a/apps/ferrisquote-api/src/handlers/field_handlers.rs
+++ b/apps/ferrisquote-api/src/handlers/field_handlers.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
 };
-use ferrisquote_domain::{FieldId, StepId, domain::flows::ports::{FieldService, FlowService, StepService}};
+use ferrisquote_domain::{FieldId, StepId, domain::{estimator::ports::EstimatorService, flows::ports::{FieldService, FlowService, StepService}}};
 use validator::Validate;
 
 use crate::{
@@ -30,8 +30,8 @@ use super::mappers::{map_field_config_from_dto, map_field_to_response, map_flow_
     ),
     tag = "fields"
 )]
-pub async fn add_field<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn add_field<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(step_id): Path<String>,
     Json(request): Json<CreateFieldRequest>,
 ) -> ApiResult<(StatusCode, Json<ApiResponse<FieldResponse>>)> {
@@ -63,8 +63,8 @@ pub async fn add_field<S: FlowService + StepService + FieldService>(
     ),
     tag = "fields"
 )]
-pub async fn update_field_config<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn update_field_config<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(field_id): Path<String>,
     Json(request): Json<UpdateFieldConfigRequest>,
 ) -> ApiResult<Json<ApiResponse<FieldResponse>>> {
@@ -94,8 +94,8 @@ pub async fn update_field_config<S: FlowService + StepService + FieldService>(
     ),
     tag = "fields"
 )]
-pub async fn remove_field<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn remove_field<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(field_id): Path<String>,
 ) -> ApiResult<(StatusCode, Json<ApiResponse<MessageResponse>>)> {
     let field_id = FieldId::from_uuid(uuid::Uuid::parse_str(&field_id)?);
@@ -121,8 +121,8 @@ pub async fn remove_field<S: FlowService + StepService + FieldService>(
     ),
     tag = "fields"
 )]
-pub async fn move_field<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn move_field<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(field_id): Path<String>,
     Json(request): Json<MoveFieldRequest>,
 ) -> ApiResult<Json<ApiResponse<crate::dto::FlowResponse>>> {

--- a/apps/ferrisquote-api/src/handlers/flow_handlers.rs
+++ b/apps/ferrisquote-api/src/handlers/flow_handlers.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
 };
-use ferrisquote_domain::{FlowId, domain::flows::ports::{FieldService, FlowService, StepService}};
+use ferrisquote_domain::{FlowId, domain::{estimator::ports::EstimatorService, flows::ports::{FieldService, FlowService, StepService}}};
 use validator::Validate;
 
 use crate::{
@@ -28,8 +28,8 @@ use super::mappers::map_flow_to_response;
     ),
     tag = "flows"
 )]
-pub async fn create_flow<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn create_flow<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Json(request): Json<CreateFlowRequest>,
 ) -> ApiResult<(StatusCode, Json<ApiResponse<FlowResponse>>)> {
     request.validate()?;
@@ -51,8 +51,8 @@ pub async fn create_flow<S: FlowService + StepService + FieldService>(
     ),
     tag = "flows"
 )]
-pub async fn get_flow<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn get_flow<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(flow_id): Path<String>,
 ) -> ApiResult<Json<ApiResponse<FlowResponse>>> {
     let flow_id = FlowId::from_uuid(uuid::Uuid::parse_str(&flow_id)?);
@@ -71,8 +71,8 @@ pub async fn get_flow<S: FlowService + StepService + FieldService>(
     ),
     tag = "flows"
 )]
-pub async fn list_flows<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn list_flows<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
 ) -> ApiResult<Json<ApiResponse<FlowListResponse>>> {
     let flows = state.flow_service.list_flows().await?;
 
@@ -104,8 +104,8 @@ pub async fn list_flows<S: FlowService + StepService + FieldService>(
     ),
     tag = "flows"
 )]
-pub async fn update_flow_metadata<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn update_flow_metadata<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(flow_id): Path<String>,
     Json(request): Json<UpdateFlowMetadataRequest>,
 ) -> ApiResult<Json<ApiResponse<FlowResponse>>> {
@@ -133,8 +133,8 @@ pub async fn update_flow_metadata<S: FlowService + StepService + FieldService>(
     ),
     tag = "flows"
 )]
-pub async fn delete_flow<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn delete_flow<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(flow_id): Path<String>,
 ) -> ApiResult<(StatusCode, Json<ApiResponse<MessageResponse>>)> {
     let flow_id = FlowId::from_uuid(uuid::Uuid::parse_str(&flow_id)?);

--- a/apps/ferrisquote-api/src/handlers/mod.rs
+++ b/apps/ferrisquote-api/src/handlers/mod.rs
@@ -1,7 +1,9 @@
+pub mod estimator_handlers;
 pub mod field_handlers;
 pub mod flow_handlers;
 pub mod mappers;
 pub mod step_handlers;
+pub use estimator_handlers::*;
 pub use field_handlers::*;
 pub use flow_handlers::*;
 pub use step_handlers::*;

--- a/apps/ferrisquote-api/src/handlers/step_handlers.rs
+++ b/apps/ferrisquote-api/src/handlers/step_handlers.rs
@@ -4,7 +4,7 @@ use axum::{
     Json,
 };
 use ferrisquote_domain::{
-    domain::flows::ports::{FieldService, FlowService, StepService},
+    domain::{estimator::ports::EstimatorService, flows::ports::{FieldService, FlowService, StepService}},
     FlowId, StepId,
 };
 use validator::Validate;
@@ -30,8 +30,8 @@ use super::mappers::{map_flow_to_response, map_step_to_response};
     ),
     tag = "steps"
 )]
-pub async fn add_step<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn add_step<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(flow_id): Path<String>,
     Json(request): Json<CreateStepRequest>,
 ) -> ApiResult<(StatusCode, Json<ApiResponse<StepResponse>>)> {
@@ -55,8 +55,8 @@ pub async fn add_step<S: FlowService + StepService + FieldService>(
     ),
     tag = "steps"
 )]
-pub async fn remove_step<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn remove_step<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(step_id): Path<String>,
 ) -> ApiResult<(StatusCode, Json<ApiResponse<MessageResponse>>)> {
     let step_id = StepId::from_uuid(uuid::Uuid::parse_str(&step_id)?);
@@ -82,8 +82,8 @@ pub async fn remove_step<S: FlowService + StepService + FieldService>(
     ),
     tag = "steps"
 )]
-pub async fn reorder_step<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn reorder_step<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(step_id): Path<String>,
     Json(request): Json<ReorderStepRequest>,
 ) -> ApiResult<Json<ApiResponse<crate::dto::FlowResponse>>> {
@@ -120,8 +120,8 @@ pub async fn reorder_step<S: FlowService + StepService + FieldService>(
     ),
     tag = "steps"
 )]
-pub async fn update_step_metadata<S: FlowService + StepService + FieldService>(
-    State(state): State<AppState<S>>,
+pub async fn update_step_metadata<FS: FlowService + StepService + FieldService, ES: EstimatorService>(
+    State(state): State<AppState<FS, ES>>,
     Path(step_id): Path<String>,
     Json(request): Json<UpdateStepMetadataRequest>,
 ) -> ApiResult<Json<ApiResponse<StepResponse>>> {

--- a/apps/ferrisquote-api/src/main.rs
+++ b/apps/ferrisquote-api/src/main.rs
@@ -1,8 +1,12 @@
 use ferrisquote_domain::domain::{
+    estimator::services::EstimatorServiceImpl,
     flows::services::FlowServiceImpl,
     rank::services::LexoRankProvider,
 };
-use ferrisquote_postgres::repositories::flow_repository::PostgresFlowRepository;
+use ferrisquote_postgres::repositories::{
+    estimator_repository::PostgresEstimatorRepository,
+    flow_repository::PostgresFlowRepository,
+};
 use sqlx::postgres::PgPoolOptions;
 use std::sync::Arc;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -42,17 +46,22 @@ async fn main() -> anyhow::Result<()> {
         .await
         .expect("failed to connect to Postgres");
 
-    let repo = PostgresFlowRepository::new(pool);
+    let pg_pool = Arc::new(pool);
+
+    let flow_repo = PostgresFlowRepository::with_pool(pg_pool.clone());
+    let estimator_repo = PostgresEstimatorRepository::with_pool(pg_pool);
     let rank_service = LexoRankProvider;
 
     let flow_service = FlowServiceImpl::new(
-        repo.clone(),
-        repo.clone(),
-        repo.clone(),
+        flow_repo.clone(),
+        flow_repo.clone(),
+        flow_repo.clone(),
         rank_service,
     );
 
-    let app_state = AppState::new(Arc::new(flow_service));
+    let estimator_service = EstimatorServiceImpl::new(estimator_repo);
+
+    let app_state = AppState::new(Arc::new(flow_service), Arc::new(estimator_service));
 
     let app = build_routes(app_state);
 

--- a/apps/ferrisquote-api/src/openapi.rs
+++ b/apps/ferrisquote-api/src/openapi.rs
@@ -1,10 +1,12 @@
 use utoipa::OpenApi;
 
 use crate::dto::{
-    ApiResponse, CreateFieldRequest, CreateFlowRequest, CreateStepRequest, FieldConfigDto,
-    FieldResponse, FlowListResponse, FlowResponse, FlowSummaryResponse, MessageResponse,
-    MoveFieldRequest, ReorderStepRequest, StepResponse, UpdateFieldConfigRequest,
-    UpdateFlowMetadataRequest, UpdateStepMetadataRequest,
+    ApiResponse, CreateEstimatorRequest, CreateFieldRequest, CreateFlowRequest,
+    CreateStepRequest, CreateVariableRequest, EstimatorListResponse, EstimatorResponse,
+    EvaluateRequest, EvaluateResponse, EvaluateSubmissionRequest, FieldConfigDto, FieldResponse,
+    FlowListResponse, FlowResponse, FlowSummaryResponse, MessageResponse, MoveFieldRequest,
+    ReorderStepRequest, StepResponse, UpdateEstimatorRequest, UpdateFieldConfigRequest,
+    UpdateFlowMetadataRequest, UpdateStepMetadataRequest, UpdateVariableRequest, VariableResponse,
 };
 
 #[derive(OpenApi)]
@@ -12,7 +14,7 @@ use crate::dto::{
     info(
         title = "FerrisQuote API",
         version = "0.1.0",
-        description = "API for managing quote flows, steps and fields"
+        description = "API for managing quote flows, steps, fields and estimators"
     ),
     paths(
         crate::handlers::flow_handlers::create_flow,
@@ -28,6 +30,16 @@ use crate::dto::{
         crate::handlers::field_handlers::update_field_config,
         crate::handlers::field_handlers::remove_field,
         crate::handlers::field_handlers::move_field,
+        crate::handlers::estimator_handlers::create_estimator,
+        crate::handlers::estimator_handlers::list_estimators,
+        crate::handlers::estimator_handlers::get_estimator,
+        crate::handlers::estimator_handlers::update_estimator,
+        crate::handlers::estimator_handlers::delete_estimator,
+        crate::handlers::estimator_handlers::add_variable,
+        crate::handlers::estimator_handlers::update_variable,
+        crate::handlers::estimator_handlers::remove_variable,
+        crate::handlers::estimator_handlers::evaluate,
+        crate::handlers::estimator_handlers::evaluate_submission,
     ),
     components(schemas(
         CreateFlowRequest,
@@ -44,17 +56,33 @@ use crate::dto::{
         MoveFieldRequest,
         FieldResponse,
         FieldConfigDto,
+        CreateEstimatorRequest,
+        UpdateEstimatorRequest,
+        EstimatorResponse,
+        EstimatorListResponse,
+        CreateVariableRequest,
+        UpdateVariableRequest,
+        VariableResponse,
+        EvaluateRequest,
+        EvaluateSubmissionRequest,
+        EvaluateResponse,
         MessageResponse,
         ApiResponse<FlowResponse>,
         ApiResponse<FlowListResponse>,
         ApiResponse<StepResponse>,
         ApiResponse<FieldResponse>,
+        ApiResponse<EstimatorResponse>,
+        ApiResponse<EstimatorListResponse>,
+        ApiResponse<VariableResponse>,
+        ApiResponse<EvaluateResponse>,
         ApiResponse<MessageResponse>,
     )),
     tags(
         (name = "flows", description = "Flow management"),
         (name = "steps", description = "Step management"),
         (name = "fields", description = "Field management"),
+        (name = "estimators", description = "Estimator management"),
+        (name = "estimator_variables", description = "Estimator variable management"),
     )
 )]
 pub struct ApiDoc;

--- a/apps/ferrisquote-api/src/routes/build_routes.rs
+++ b/apps/ferrisquote-api/src/routes/build_routes.rs
@@ -3,13 +3,23 @@ use tower_http::cors::{AllowHeaders, AllowMethods, CorsLayer};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use ferrisquote_domain::domain::flows::ports::{FieldService, FlowService, StepService};
+use ferrisquote_domain::domain::{
+    estimator::ports::EstimatorService,
+    flows::ports::{FieldService, FlowService, StepService},
+};
 
-use crate::{openapi::ApiDoc, routes::flow_routes, state::AppState};
+use crate::{
+    openapi::ApiDoc,
+    routes::{estimator_routes, flow_routes},
+    state::AppState,
+};
 
 /// Build the complete API router with all routes
-pub fn build_routes<S: FlowService + StepService + FieldService + Clone + 'static>(
-    state: AppState<S>,
+pub fn build_routes<
+    FS: FlowService + StepService + FieldService + Clone + 'static,
+    ES: EstimatorService + Clone + 'static,
+>(
+    state: AppState<FS, ES>,
 ) -> Router {
     let allowed_origins = std::env::var("ALLOWED_ORIGINS")
         .unwrap_or_else(|_| "http://localhost:5173".to_string());
@@ -27,6 +37,9 @@ pub fn build_routes<S: FlowService + StepService + FieldService + Clone + 'stati
     let api = Router::new()
         .route("/health", get(health_check))
         .nest("/api/v1/flows", flow_routes::flow_routes())
+        .nest("/api/v1/flows", estimator_routes::estimator_flow_routes())
+        .nest("/api/v1/estimators", estimator_routes::estimator_routes())
+        .nest("/api/v1/variables", estimator_routes::variable_routes())
         .with_state(state);
 
     Router::new()

--- a/apps/ferrisquote-api/src/routes/estimator_routes.rs
+++ b/apps/ferrisquote-api/src/routes/estimator_routes.rs
@@ -1,0 +1,42 @@
+use axum::{
+    Router,
+    routing::{delete, get, post, put},
+};
+
+use ferrisquote_domain::domain::{
+    estimator::ports::EstimatorService,
+    flows::ports::{FieldService, FlowService, StepService},
+};
+
+use crate::{handlers, state::AppState};
+
+/// Estimator routes nested under /flows (create + list by flow)
+pub fn estimator_flow_routes<FS: FlowService + StepService + FieldService + Clone + 'static, ES: EstimatorService + Clone + 'static>(
+) -> Router<AppState<FS, ES>> {
+    Router::new()
+        .route("/{flow_id}/estimators", post(handlers::create_estimator))
+        .route("/{flow_id}/estimators", get(handlers::list_estimators))
+}
+
+/// Standalone estimator routes under /estimators
+pub fn estimator_routes<FS: FlowService + StepService + FieldService + Clone + 'static, ES: EstimatorService + Clone + 'static>(
+) -> Router<AppState<FS, ES>> {
+    Router::new()
+        .route("/{estimator_id}", get(handlers::get_estimator))
+        .route("/{estimator_id}", put(handlers::update_estimator))
+        .route("/{estimator_id}", delete(handlers::delete_estimator))
+        .route("/{estimator_id}/variables", post(handlers::add_variable))
+        .route("/{estimator_id}/evaluate", post(handlers::evaluate))
+        .route(
+            "/{estimator_id}/evaluate-submission",
+            post(handlers::evaluate_submission),
+        )
+}
+
+/// Variable routes under /variables
+pub fn variable_routes<FS: FlowService + StepService + FieldService + Clone + 'static, ES: EstimatorService + Clone + 'static>(
+) -> Router<AppState<FS, ES>> {
+    Router::new()
+        .route("/{variable_id}", put(handlers::update_variable))
+        .route("/{variable_id}", delete(handlers::remove_variable))
+}

--- a/apps/ferrisquote-api/src/routes/flow_routes.rs
+++ b/apps/ferrisquote-api/src/routes/flow_routes.rs
@@ -3,13 +3,16 @@ use axum::{
     routing::{delete, get, post, put},
 };
 
-use ferrisquote_domain::domain::flows::ports::{FieldService, FlowService, StepService};
+use ferrisquote_domain::domain::{
+    estimator::ports::EstimatorService,
+    flows::ports::{FieldService, FlowService, StepService},
+};
 
 use crate::{handlers, state::AppState};
 
 /// Flow-specific routes
-pub fn flow_routes<S: FlowService + StepService + FieldService + Clone + 'static>(
-) -> Router<AppState<S>> {
+pub fn flow_routes<FS: FlowService + StepService + FieldService + Clone + 'static, ES: EstimatorService + Clone + 'static>(
+) -> Router<AppState<FS, ES>> {
     Router::new()
         // Flow CRUD
         .route("/", post(handlers::create_flow))

--- a/apps/ferrisquote-api/src/routes/mod.rs
+++ b/apps/ferrisquote-api/src/routes/mod.rs
@@ -1,2 +1,3 @@
 pub mod build_routes;
+pub mod estimator_routes;
 pub mod flow_routes;

--- a/apps/ferrisquote-api/src/state.rs
+++ b/apps/ferrisquote-api/src/state.rs
@@ -1,15 +1,22 @@
 use std::sync::Arc;
 
-use ferrisquote_domain::domain::flows::ports::{FieldService, FlowService, StepService};
+use ferrisquote_domain::domain::{
+    estimator::ports::EstimatorService,
+    flows::ports::{FieldService, FlowService, StepService},
+};
 
 /// Application state shared across all handlers
 #[derive(Clone)]
-pub struct AppState<S: FlowService + StepService + FieldService> {
-    pub flow_service: Arc<S>,
+pub struct AppState<FS: FlowService + StepService + FieldService, ES: EstimatorService> {
+    pub flow_service: Arc<FS>,
+    pub estimator_service: Arc<ES>,
 }
 
-impl<S: FlowService + StepService + FieldService> AppState<S> {
-    pub fn new(flow_service: Arc<S>) -> Self {
-        Self { flow_service }
+impl<FS: FlowService + StepService + FieldService, ES: EstimatorService> AppState<FS, ES> {
+    pub fn new(flow_service: Arc<FS>, estimator_service: Arc<ES>) -> Self {
+        Self {
+            flow_service,
+            estimator_service,
+        }
     }
 }

--- a/libs/ferrisquote-domain/src/domain/estimator/services.rs
+++ b/libs/ferrisquote-domain/src/domain/estimator/services.rs
@@ -12,6 +12,7 @@ use super::{
     ports::{EstimatorRepository, EstimatorService},
 };
 
+#[derive(Clone)]
 pub struct EstimatorServiceImpl<ER> {
     repo: ER,
 }


### PR DESCRIPTION
This pull request adds comprehensive support for estimator management to the API, including full CRUD operations and evaluation endpoints. It introduces new DTOs and handler functions for estimators and their variables, and updates the API's handler generics and imports to accommodate these changes. The update also ensures that the application state and handler signatures are compatible with the new estimator functionality.

The most important changes are:

**Estimator API Implementation:**

* Added a new module `estimator_handlers` with full CRUD endpoints for estimators and their variables, as well as evaluation endpoints (`evaluate` and `evaluate_submission`). This includes mapping functions and OpenAPI documentation annotations.
* Introduced new request and response DTOs for estimators and variables in `dto/estimators.rs`, supporting validation and OpenAPI schema generation.
* Re-exported the new estimator DTOs in the main `dto/mod.rs` module for easier access throughout the codebase.
* Registered the new handler module in `handlers/mod.rs` and made its functions available for routing.

**Handler and State Refactoring:**

* Updated all handler functions in `field_handlers.rs`, `flow_handlers.rs`, and `step_handlers.rs` to accept both `FlowService` and `EstimatorService` as generic parameters, and updated their `AppState` usage accordingly. This ensures all endpoints are compatible with the new estimator logic. [[1]](diffhunk://#diff-fddd395fa47c1466eb7cc1d3112ae02395d066e3f25189cf5c6876fa971c53edL6-R6) [[2]](diffhunk://#diff-fddd395fa47c1466eb7cc1d3112ae02395d066e3f25189cf5c6876fa971c53edL33-R34) [[3]](diffhunk://#diff-fddd395fa47c1466eb7cc1d3112ae02395d066e3f25189cf5c6876fa971c53edL66-R67) [[4]](diffhunk://#diff-fddd395fa47c1466eb7cc1d3112ae02395d066e3f25189cf5c6876fa971c53edL97-R98) [[5]](diffhunk://#diff-fddd395fa47c1466eb7cc1d3112ae02395d066e3f25189cf5c6876fa971c53edL124-R125) [[6]](diffhunk://#diff-69e79b3879a39c665cc87cb79f061cc82f5d8ee5d04a0bdeb69b3f9418787b2eL6-R6) [[7]](diffhunk://#diff-69e79b3879a39c665cc87cb79f061cc82f5d8ee5d04a0bdeb69b3f9418787b2eL31-R32) [[8]](diffhunk://#diff-69e79b3879a39c665cc87cb79f061cc82f5d8ee5d04a0bdeb69b3f9418787b2eL54-R55) [[9]](diffhunk://#diff-69e79b3879a39c665cc87cb79f061cc82f5d8ee5d04a0bdeb69b3f9418787b2eL74-R75) [[10]](diffhunk://#diff-69e79b3879a39c665cc87cb79f061cc82f5d8ee5d04a0bdeb69b3f9418787b2eL107-R108) [[11]](diffhunk://#diff-69e79b3879a39c665cc87cb79f061cc82f5d8ee5d04a0bdeb69b3f9418787b2eL136-R137) [[12]](diffhunk://#diff-5eee0ba8adfa8cca1bf3197f51c131109f6c6c29489ea99c124f302d9ccf8a29L7-R7)