### PR TITLE
fix(front) sidenav edition closing flow canvas + focus on node when double click

### DIFF
--- a/apps/ferrisquote-webapp/src/pages/flows/feature/page-flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/page-flow-canvas.tsx
@@ -753,7 +753,7 @@ function PageFlowCanvasInner() {
       return next
     })
     setPanelState((prev) =>
-      prev && "stepId" in prev && prev.stepId === node.id
+      prev?.mode === "step-details" && prev.stepId === node.id
         ? null
         : { mode: "step-details", stepId: node.id },
     )

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/page-flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/page-flow-canvas.tsx
@@ -723,40 +723,27 @@ function PageFlowCanvasInner() {
 
     if (node.type === "estimatorNode") {
       const estimatorId = node.id.replace("estimator-", "")
-      setPanelState((prev) =>
-        prev?.mode === "estimator-details" && prev.estimatorId === estimatorId
-          ? null
-          : { mode: "estimator-details", estimatorId },
-      )
+      setPanelState({ mode: "estimator-details", estimatorId })
       return
     }
 
     if (node.type === "fieldNode") {
       const fieldId = node.id.replace("field-", "")
-      // Find which step owns this field
       const stepId = flow?.steps.find((s) => s.fields.some((f) => f.id === fieldId))?.id
       if (stepId) {
-        setPanelState((prev) =>
-          prev?.mode === "edit-field" && prev.fieldId === fieldId
-            ? { mode: "step-details", stepId }
-            : { mode: "edit-field", fieldId, stepId },
-        )
+        setPanelState({ mode: "edit-field", fieldId, stepId })
       }
       return
     }
 
     if (node.type !== "stepNode") return
-    // Single click: select + expand (keep others open)
+    // Single click: select + expand (keep others open, no toggle-close)
     setExpandedStepIds((prev) => {
       const next = new Set(prev)
       next.add(node.id)
       return next
     })
-    setPanelState((prev) =>
-      prev?.mode === "step-details" && prev.stepId === node.id
-        ? null
-        : { mode: "step-details", stepId: node.id },
-    )
+    setPanelState({ mode: "step-details", stepId: node.id })
   }
 
   function handleNodeDoubleClick(_: React.MouseEvent, node: Node) {

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/page-flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/page-flow-canvas.tsx
@@ -400,7 +400,7 @@ function PageFlowCanvasInner() {
   const { flowId } = useParams<{ flowId: string }>()
   const setLastFlowId = useFlowStore((s) => s.setLastFlowId)
   const reactFlowWrapper = useRef<HTMLDivElement>(null)
-  const { screenToFlowPosition, getNodes } = useReactFlow()
+  const { screenToFlowPosition, getNodes, fitView, setCenter, getZoom } = useReactFlow()
 
   const { data: flowData, error } = useGetFlow(flowId ?? "")
   const { data: estimatorsData } = useListEstimators(flowId ?? "")
@@ -747,16 +747,28 @@ function PageFlowCanvasInner() {
   }
 
   function handleNodeDoubleClick(_: React.MouseEvent, node: Node) {
-    if (node.type !== "stepNode") return
-    // Double click: toggle exclusive — collapse all others, or collapse this one
-    setExpandedStepIds((prev) => {
-      if (prev.has(node.id) && prev.size === 1) {
-        // Already the only one expanded → collapse it
-        return new Set()
-      }
-      // Expand only this one (collapse all others)
-      return new Set([node.id])
-    })
+    if (node.type === "stepNode") {
+      // Exclusive expand: collapse all others, keep only this one expanded
+      setExpandedStepIds(new Set([node.id]))
+
+      const step = flow?.steps.find((s) => s.id === node.id)
+      const fieldIds = step?.fields.map((f) => ({ id: `field-${f.id}` })) ?? []
+      // Wait a frame so the newly-rendered field nodes are registered
+      requestAnimationFrame(() => {
+        fitView({
+          nodes: [{ id: node.id }, ...fieldIds],
+          padding: 0.2,
+          duration: 400,
+        })
+      })
+      return
+    }
+
+    if (node.type === "fieldNode" || node.type === "estimatorNode") {
+      const cx = node.position.x + (node.measured?.width ?? 200) / 2
+      const cy = node.position.y + (node.measured?.height ?? 56) / 2
+      setCenter(cx, cy, { zoom: getZoom(), duration: 400 })
+    }
   }
 
   // ─── Step reorder via node drag ───────────────────────────────────────────
@@ -971,6 +983,7 @@ function PageFlowCanvasInner() {
               onDragOver={onDragOver}
               onDrop={onDrop}
               fitView
+              zoomOnDoubleClick={false}
               nodesConnectable={false}
               edgesReconnectable={false}
               edgesFocusable={false}

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/flow-edit-sheet.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/flow-edit-sheet.tsx
@@ -376,7 +376,8 @@ function StepDetailsPanel({
         {editingTitle ? (
           <Input
             autoFocus
-            className="text-base font-semibold h-8"
+            className="flex-1 !text-base font-semibold h-7 rounded-sm border border-border/60 bg-transparent px-2 py-0 shadow-none focus-visible:border-border focus-visible:ring-0"
+            style={{ color: STEP_COLOR }}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             onBlur={() => {
@@ -407,9 +408,11 @@ function StepDetailsPanel({
             {step.title}
           </button>
         )}
-        <Button variant="ghost" size="icon" className="shrink-0 h-7 w-7" onClick={onClose}>
-          <X className="w-4 h-4" />
-        </Button>
+        {!editingTitle && (
+          <Button variant="ghost" size="icon" className="shrink-0 h-7 w-7" onClick={onClose}>
+            <X className="w-4 h-4" />
+          </Button>
+        )}
       </div>
 
       {/* Repeatable configuration */}
@@ -800,7 +803,8 @@ function EstimatorDetailsPanel({
         {editingName ? (
           <Input
             autoFocus
-            className="text-base font-semibold h-8"
+            className="flex-1 !text-base font-semibold h-7 rounded-sm border border-border/60 bg-transparent px-2 py-0 shadow-none focus-visible:border-border focus-visible:ring-0"
+            style={{ color: ROSE }}
             value={name}
             onChange={(e) => setName(e.target.value)}
             onBlur={() => {
@@ -827,9 +831,11 @@ function EstimatorDetailsPanel({
             {estimator.name}
           </button>
         )}
-        <Button variant="ghost" size="icon" className="shrink-0 h-7 w-7" onClick={onClose}>
-          <X className="w-4 h-4" />
-        </Button>
+        {!editingName && (
+          <Button variant="ghost" size="icon" className="shrink-0 h-7 w-7" onClick={onClose}>
+            <X className="w-4 h-4" />
+          </Button>
+        )}
       </div>
 
       <div className="flex flex-col gap-3 px-5 py-4 flex-1 overflow-y-auto">


### PR DESCRIPTION
This pull request improves the usability and visual consistency of the flow editing experience in the FerrisQuote web app. The main changes include refining the behavior of the flow canvas interactions (especially node clicks and double-clicks), enhancing the look and feel of input fields in detail panels, and improving the panel close button logic.

**Flow canvas interaction improvements:**

* Node click and double-click logic in `PageFlowCanvasInner` was refactored for clarity and better UX: single-clicking any node now always opens its details panel, while double-clicking a step node exclusively expands it and smoothly fits related nodes into view; double-clicking a field or estimator node centers and zooms in on it.
* The React Flow instance now disables zooming on double-click (to avoid accidental zooms when double-clicking nodes for expansion/centering).
* Additional React Flow methods (`fitView`, `setCenter`, `getZoom`) are now used for improved viewport control.

**Detail panel UI enhancements:**

* The input fields for step and estimator titles/names have been restyled for better alignment, padding, and visual consistency with the app theme. [[1]](diffhunk://#diff-2f761e5bf14a6c0374f49c3fed0051eb0dcc4584e35ecc12633809652ebe37edL379-R380) [[2]](diffhunk://#diff-2f761e5bf14a6c0374f49c3fed0051eb0dcc4584e35ecc12633809652ebe37edL803-R807)
* The close button in both the Step and Estimator details panels now only appears when not editing the title/name, reducing accidental panel closure during edits. [[1]](diffhunk://#diff-2f761e5bf14a6c0374f49c3fed0051eb0dcc4584e35ecc12633809652ebe37edR411-R415) [[2]](diffhunk://#diff-2f761e5bf14a6c0374f49c3fed0051eb0dcc4584e35ecc12633809652ebe37edR834-R838)