### PR TITLE
feat(core): user entity ports and persistence implementation

### DIFF
--- a/libs/ferrisquote-domain/src/domain/mod.rs
+++ b/libs/ferrisquote-domain/src/domain/mod.rs
@@ -2,4 +2,5 @@ pub mod error;
 pub mod estimator;
 pub mod flows;
 pub mod rank;
+pub mod user;
 pub use error::DomainError;

--- a/libs/ferrisquote-domain/src/domain/user.rs
+++ b/libs/ferrisquote-domain/src/domain/user.rs
@@ -1,0 +1,3 @@
+pub mod entities;
+pub mod ports;
+pub mod services;

--- a/libs/ferrisquote-domain/src/domain/user/entities.rs
+++ b/libs/ferrisquote-domain/src/domain/user/entities.rs
@@ -1,0 +1,5 @@
+pub mod id;
+pub mod user;
+
+pub use id::UserId;
+pub use user::User;

--- a/libs/ferrisquote-domain/src/domain/user/entities/id.rs
+++ b/libs/ferrisquote-domain/src/domain/user/entities/id.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct UserId(Uuid);
+
+impl UserId {
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+
+    pub fn from_uuid(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+
+    pub fn into_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+impl Default for UserId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for UserId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::str::FromStr for UserId {
+    type Err = uuid::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Uuid::parse_str(s)?))
+    }
+}

--- a/libs/ferrisquote-domain/src/domain/user/entities/user.rs
+++ b/libs/ferrisquote-domain/src/domain/user/entities/user.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+use super::id::UserId;
+
+/// Application-level user. Distinct from `ferrisquote-auth::User` which
+/// represents an authenticated identity coming from an IdP — this aggregate
+/// is the owner/actor for domain objects (flows, quotes, estimators).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct User {
+    pub id: UserId,
+    pub mail: String,
+    pub first_name: String,
+    pub last_name: String,
+}
+
+impl User {
+    pub fn new(mail: String, first_name: String, last_name: String) -> Self {
+        Self {
+            id: UserId::new(),
+            mail,
+            first_name,
+            last_name,
+        }
+    }
+
+    pub fn with_id(id: UserId, mail: String, first_name: String, last_name: String) -> Self {
+        Self {
+            id,
+            mail,
+            first_name,
+            last_name,
+        }
+    }
+}

--- a/libs/ferrisquote-domain/src/domain/user/ports.rs
+++ b/libs/ferrisquote-domain/src/domain/user/ports.rs
@@ -1,0 +1,54 @@
+use std::future::Future;
+
+use crate::domain::error::DomainError;
+
+use super::entities::{User, UserId};
+
+/// Persistence contract for user aggregates. Technology-agnostic.
+pub trait UserRepository: Send + Sync {
+    fn create(&self, user: User) -> impl Future<Output = Result<User, DomainError>> + Send;
+
+    fn get_by_id(&self, id: UserId) -> impl Future<Output = Result<User, DomainError>> + Send;
+
+    fn get_by_mail(&self, mail: &str)
+        -> impl Future<Output = Result<User, DomainError>> + Send;
+
+    /// Partial update — only `Some(...)` fields are written.
+    fn update(
+        &self,
+        id: UserId,
+        mail: Option<String>,
+        first_name: Option<String>,
+        last_name: Option<String>,
+    ) -> impl Future<Output = Result<User, DomainError>> + Send;
+
+    fn delete(&self, id: UserId) -> impl Future<Output = Result<(), DomainError>> + Send;
+}
+
+/// Domain service — orchestrates business rules (validation, uniqueness
+/// checks, welcome hooks, etc.) on top of the repository.
+pub trait UserService: Send + Sync {
+    fn create_user(
+        &self,
+        mail: String,
+        first_name: String,
+        last_name: String,
+    ) -> impl Future<Output = Result<User, DomainError>> + Send;
+
+    fn get_user(&self, id: UserId) -> impl Future<Output = Result<User, DomainError>> + Send;
+
+    fn get_user_by_mail(
+        &self,
+        mail: &str,
+    ) -> impl Future<Output = Result<User, DomainError>> + Send;
+
+    fn update_user(
+        &self,
+        id: UserId,
+        mail: Option<String>,
+        first_name: Option<String>,
+        last_name: Option<String>,
+    ) -> impl Future<Output = Result<User, DomainError>> + Send;
+
+    fn delete_user(&self, id: UserId) -> impl Future<Output = Result<(), DomainError>> + Send;
+}

--- a/libs/ferrisquote-domain/src/domain/user/services.rs
+++ b/libs/ferrisquote-domain/src/domain/user/services.rs
@@ -1,0 +1,134 @@
+use crate::domain::error::DomainError;
+
+use super::entities::{User, UserId};
+use super::ports::{UserRepository, UserService};
+
+#[derive(Clone)]
+pub struct UserServiceImpl<UR> {
+    repo: UR,
+}
+
+impl<UR> UserServiceImpl<UR> {
+    pub fn new(repo: UR) -> Self {
+        Self { repo }
+    }
+}
+
+/// Minimal email validation. Centralized so the rule stays one-liner away.
+fn validate_mail(mail: &str) -> Result<(), DomainError> {
+    let trimmed = mail.trim();
+    if trimmed.is_empty() {
+        return Err(DomainError::validation("Email cannot be empty"));
+    }
+    // Must contain exactly one '@' with non-empty local + domain parts
+    let mut parts = trimmed.split('@');
+    let local = parts.next().unwrap_or("");
+    let domain = parts.next().unwrap_or("");
+    if local.is_empty() || domain.is_empty() || parts.next().is_some() || !domain.contains('.') {
+        return Err(DomainError::validation("Invalid email format"));
+    }
+    Ok(())
+}
+
+fn validate_name(field: &str, value: &str) -> Result<(), DomainError> {
+    if value.trim().is_empty() {
+        return Err(DomainError::validation(format!("{field} cannot be empty")));
+    }
+    if value.len() > 255 {
+        return Err(DomainError::validation(format!(
+            "{field} must be at most 255 characters"
+        )));
+    }
+    Ok(())
+}
+
+impl<UR> UserService for UserServiceImpl<UR>
+where
+    UR: UserRepository + Send + Sync,
+{
+    async fn create_user(
+        &self,
+        mail: String,
+        first_name: String,
+        last_name: String,
+    ) -> Result<User, DomainError> {
+        validate_mail(&mail)?;
+        validate_name("First name", &first_name)?;
+        validate_name("Last name", &last_name)?;
+        let user = User::new(mail, first_name, last_name);
+        self.repo.create(user).await
+    }
+
+    async fn get_user(&self, id: UserId) -> Result<User, DomainError> {
+        self.repo.get_by_id(id).await
+    }
+
+    async fn get_user_by_mail(&self, mail: &str) -> Result<User, DomainError> {
+        self.repo.get_by_mail(mail).await
+    }
+
+    async fn update_user(
+        &self,
+        id: UserId,
+        mail: Option<String>,
+        first_name: Option<String>,
+        last_name: Option<String>,
+    ) -> Result<User, DomainError> {
+        if let Some(m) = &mail {
+            validate_mail(m)?;
+        }
+        if let Some(f) = &first_name {
+            validate_name("First name", f)?;
+        }
+        if let Some(l) = &last_name {
+            validate_name("Last name", l)?;
+        }
+        self.repo.update(id, mail, first_name, last_name).await
+    }
+
+    async fn delete_user(&self, id: UserId) -> Result<(), DomainError> {
+        self.repo.delete(id).await
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_mail_accepts_valid() {
+        assert!(validate_mail("foo@bar.com").is_ok());
+        assert!(validate_mail("a.b+c@x.y.z").is_ok());
+    }
+
+    #[test]
+    fn test_validate_mail_rejects_empty() {
+        assert!(validate_mail("").is_err());
+        assert!(validate_mail("   ").is_err());
+    }
+
+    #[test]
+    fn test_validate_mail_rejects_malformed() {
+        assert!(validate_mail("no-at-sign").is_err());
+        assert!(validate_mail("@nohost.com").is_err());
+        assert!(validate_mail("nodomain@").is_err());
+        assert!(validate_mail("a@b").is_err()); // no TLD separator
+        assert!(validate_mail("a@b@c.com").is_err()); // multiple @
+    }
+
+    #[test]
+    fn test_validate_name_accepts_valid() {
+        assert!(validate_name("First", "Alice").is_ok());
+    }
+
+    #[test]
+    fn test_validate_name_rejects_empty_or_too_long() {
+        assert!(validate_name("First", "").is_err());
+        assert!(validate_name("First", "   ").is_err());
+        assert!(validate_name("First", &"x".repeat(256)).is_err());
+    }
+}

--- a/libs/ferrisquote-domain/src/lib.rs
+++ b/libs/ferrisquote-domain/src/lib.rs
@@ -14,3 +14,4 @@ pub use domain::flows::entities::{
     ids::{FieldId, FlowId, StepId},
     step::Step,
 };
+pub use domain::user::entities::{User, UserId};

--- a/libs/ferrisquote-postgres/migrations/20260418000000_create_users_table.down.sql
+++ b/libs/ferrisquote-postgres/migrations/20260418000000_create_users_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/libs/ferrisquote-postgres/migrations/20260418000000_create_users_table.up.sql
+++ b/libs/ferrisquote-postgres/migrations/20260418000000_create_users_table.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE users (
+  id UUID PRIMARY KEY,
+  mail VARCHAR(320) NOT NULL,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT users_mail_unique UNIQUE (mail)
+);
+
+CREATE INDEX idx_users_mail ON users (mail);

--- a/libs/ferrisquote-postgres/src/lib.rs
+++ b/libs/ferrisquote-postgres/src/lib.rs
@@ -2,3 +2,4 @@ pub mod repositories;
 
 pub use repositories::PostgresEstimatorRepository;
 pub use repositories::PostgresFlowRepository;
+pub use repositories::PostgresUserRepository;

--- a/libs/ferrisquote-postgres/src/repositories/mod.rs
+++ b/libs/ferrisquote-postgres/src/repositories/mod.rs
@@ -1,5 +1,7 @@
 pub mod estimator_repository;
 pub mod flow_repository;
+pub mod user_repository;
 
 pub use estimator_repository::PostgresEstimatorRepository;
 pub use flow_repository::PostgresFlowRepository;
+pub use user_repository::PostgresUserRepository;

--- a/libs/ferrisquote-postgres/src/repositories/user_repository.rs
+++ b/libs/ferrisquote-postgres/src/repositories/user_repository.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use ferrisquote_domain::domain::{
+    error::DomainError,
+    user::{
+        entities::{User, UserId},
+        ports::UserRepository,
+    },
+};
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct PostgresUserRepository {
+    pool: Arc<PgPool>,
+}
+
+impl PostgresUserRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool: Arc::new(pool) }
+    }
+
+    pub fn with_pool(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+}
+
+/// Map a sqlx error into a DomainError. Catches Postgres UNIQUE violations
+/// (SQLSTATE 23505) and surfaces them as `Conflict` rather than raw repository
+/// errors — keeps clean domain-level semantics for duplicate emails.
+fn map_sqlx_err(err: sqlx::Error) -> DomainError {
+    if let sqlx::Error::Database(db_err) = &err {
+        if db_err.code().as_deref() == Some("23505") {
+            return DomainError::conflict("A user with this email already exists");
+        }
+    }
+    DomainError::repository(err.to_string())
+}
+
+fn row_to_user(row: &sqlx::postgres::PgRow) -> User {
+    User::with_id(
+        UserId::from_uuid(row.get("id")),
+        row.get("mail"),
+        row.get("first_name"),
+        row.get("last_name"),
+    )
+}
+
+impl UserRepository for PostgresUserRepository {
+    async fn create(&self, user: User) -> Result<User, DomainError> {
+        sqlx::query(
+            "INSERT INTO users (id, mail, first_name, last_name, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, NOW(), NOW())",
+        )
+        .bind(user.id.into_uuid())
+        .bind(&user.mail)
+        .bind(&user.first_name)
+        .bind(&user.last_name)
+        .execute(&*self.pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        Ok(user)
+    }
+
+    async fn get_by_id(&self, id: UserId) -> Result<User, DomainError> {
+        let row = sqlx::query(
+            "SELECT id, mail, first_name, last_name FROM users WHERE id = $1",
+        )
+        .bind(id.into_uuid())
+        .fetch_optional(&*self.pool)
+        .await
+        .map_err(map_sqlx_err)?
+        .ok_or_else(|| DomainError::not_found("User", id.to_string()))?;
+
+        Ok(row_to_user(&row))
+    }
+
+    async fn get_by_mail(&self, mail: &str) -> Result<User, DomainError> {
+        let row = sqlx::query(
+            "SELECT id, mail, first_name, last_name FROM users WHERE mail = $1",
+        )
+        .bind(mail)
+        .fetch_optional(&*self.pool)
+        .await
+        .map_err(map_sqlx_err)?
+        .ok_or_else(|| DomainError::not_found("User", mail.to_string()))?;
+
+        Ok(row_to_user(&row))
+    }
+
+    async fn update(
+        &self,
+        id: UserId,
+        mail: Option<String>,
+        first_name: Option<String>,
+        last_name: Option<String>,
+    ) -> Result<User, DomainError> {
+        let row = sqlx::query(
+            "UPDATE users \
+             SET mail = COALESCE($2, mail), \
+                 first_name = COALESCE($3, first_name), \
+                 last_name = COALESCE($4, last_name), \
+                 updated_at = NOW() \
+             WHERE id = $1 \
+             RETURNING id, mail, first_name, last_name",
+        )
+        .bind(id.into_uuid())
+        .bind(mail)
+        .bind(first_name)
+        .bind(last_name)
+        .fetch_optional(&*self.pool)
+        .await
+        .map_err(map_sqlx_err)?
+        .ok_or_else(|| DomainError::not_found("User", id.to_string()))?;
+
+        Ok(row_to_user(&row))
+    }
+
+    async fn delete(&self, id: UserId) -> Result<(), DomainError> {
+        let result = sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(id.into_uuid())
+            .execute(&*self.pool)
+            .await
+            .map_err(map_sqlx_err)?;
+
+        if result.rows_affected() == 0 {
+            return Err(DomainError::not_found("User", id.to_string()));
+        }
+        Ok(())
+    }
+}
+
+// Silence unused imports when the types are only used through traits
+#[allow(dead_code)]
+fn _assert_uuid_used(_: Uuid) {}

--- a/libs/ferrisquote-postgres/src/repositories/user_repository.rs
+++ b/libs/ferrisquote-postgres/src/repositories/user_repository.rs
@@ -8,7 +8,6 @@ use ferrisquote_domain::domain::{
     },
 };
 use sqlx::{PgPool, Row};
-use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct PostgresUserRepository {
@@ -130,7 +129,3 @@ impl UserRepository for PostgresUserRepository {
         Ok(())
     }
 }
-
-// Silence unused imports when the types are only used through traits
-#[allow(dead_code)]
-fn _assert_uuid_used(_: Uuid) {}


### PR DESCRIPTION
This pull request introduces a complete user aggregate to the domain and persistence layers, including domain models, repository and service traits, validation logic, and a PostgreSQL-backed implementation with migrations. This enables core user CRUD operations, validation, and persistence, laying the groundwork for user management in the application.

**Domain Model & Service Layer**

- **User aggregate and value objects:** Adds the `User` aggregate and `UserId` value object in `libs/ferrisquote-domain/src/domain/user/entities`, with serialization, construction, and parsing logic. (`[[1]](diffhunk://#diff-66c74df838bd2ccee83f5e51f6913d0ce26d69c186d3c386ee0b455d09b2a163R1-R5)`, `[[2]](diffhunk://#diff-885934b762ebded40445f0f44d22b5a7399525a5eaddfa5d9ea5e114f7805f43R1-R38)`, `[[3]](diffhunk://#diff-870b97098744212c44127ca30f414a6f07a254eeaf60aa5e2912728cc1cf7e30R1-R34)`)
- **Repository and service traits:** Defines technology-agnostic `UserRepository` and `UserService` traits, supporting async CRUD operations and business logic orchestration. (`[[1]](diffhunk://#diff-bee87cab64ca7df7409b14becff35d5463c803a0aa301cf94f4babc3ceb9f757R1-R3)`, `[[2]](diffhunk://#diff-fa0483f1b199d82f3f39879393006ee3b3db8f489ffc78a8803599d5578f5174R1-R54)`)
- **Validation and service implementation:** Implements `UserServiceImpl` with centralized validation for email and names, enforcing business rules before persistence. Includes unit tests for validation. (`[libs/ferrisquote-domain/src/domain/user/services.rsR1-R134](diffhunk://#diff-dd44ef1c8b2cb0c7488e36bc55046f65be35ac0b69867f48094961dd1a4c8ba1R1-R134)`)

**Persistence Layer**

- **PostgreSQL repository implementation:** Adds `PostgresUserRepository` with async implementations of all repository methods, error mapping (including unique constraint handling), and mapping between database rows and domain objects. (`[[1]](diffhunk://#diff-8251d7a153436b9384b3cafb983acbc23e85812c3486906b0dc4f5a869164e18R3-R7)`, `[[2]](diffhunk://#diff-8f585f1f1f6f7b150c1e15bfe2e212e896f583debc12d21ed076c499d305df89R5)`, `[[3]](diffhunk://#diff-e307e23f8f087c16b8f015af645ba58833065d7a71d226cfc85a95b450f12700R1-R131)`)
- **Database migrations:** Introduces migrations to create and drop the `users` table, including unique constraint on email and indexing for efficient lookup. (`[[1]](diffhunk://#diff-288a379273205e631c2a33ac980b56cb2a22cf8cdf53a68b07d861b24e0e7185R1-R12)`, `[[2]](diffhunk://#diff-bf8759b34ee0813b2a648f6f096f511203826f5c8aae77ff25e331958d5c292fR1)`)

**Exports and Integration**

- **Module and export wiring:** Wires up the new user modules and exports `User`, `UserId`, and `PostgresUserRepository` for use throughout the codebase. (`[[1]](diffhunk://#diff-f70d62ed3a5bbac1c5bef22ea2352ab9b95ee94721606c1f4aaa661e8d26c877R5)`, `[[2]](diffhunk://#diff-dc4d4972233f20264aeaa303d1d5c697850194d0f50090a75706be95df5c77e6R17)`, `[[3]](diffhunk://#diff-8f585f1f1f6f7b150c1e15bfe2e212e896f583debc12d21ed076c499d305df89R5)`, `[[4]](diffhunk://#diff-8251d7a153436b9384b3cafb983acbc23e85812c3486906b0dc4f5a869164e18R3-R7)`)

These changes establish a robust foundation for user management in both the domain and infrastructure layers.