### PR TITLE
refactor(front): migrate estimator UI to new inputs/outputs signature

### DIFF
--- a/apps/ferrisquote-api/src/dto/estimators.rs
+++ b/apps/ferrisquote-api/src/dto/estimators.rs
@@ -43,7 +43,6 @@ pub struct CreateInputRequest {
     #[validate(length(max = 1000))]
     #[serde(default)]
     pub description: Option<String>,
-    #[serde(flatten)]
     pub parameter_type: EstimatorParameterTypeDto,
 }
 
@@ -100,7 +99,6 @@ pub struct InputResponse {
     pub id: Uuid,
     pub key: String,
     pub description: String,
-    #[serde(flatten)]
     pub parameter_type: EstimatorParameterTypeDto,
 }
 

--- a/apps/ferrisquote-webapp/src/api/api.client.ts
+++ b/apps/ferrisquote-webapp/src/api/api.client.ts
@@ -1,16 +1,58 @@
 export namespace Schemas {
   // <Schemas>
-  export type VariableResponse = { description: string; expression: string; id: string; name: string };
+  export type AggregationStrategyDto = "sum" | "average" | "max" | "min" | "count" | "first" | "last";
+  export type FieldValueDto = string | number | boolean | Array<string>;
+  export type InputBindingValueDto =
+    | { field_id: string; source: "field" }
+    | { source: "constant"; value: FieldValueDto }
+    | { binding_id: string; output_key: string; source: "binding_output" };
+  export type BindingResponse = {
+    estimator_id: string;
+    id: string;
+    inputs_mapping: Record<string, unknown>;
+    map_over_step?: (string | null) | undefined;
+    outputs_reduce_strategy: Record<string, unknown>;
+  };
+  export type ApiResponse_BindingListResponse = { data: { bindings: Array<BindingResponse> }; success: boolean };
+  export type ApiResponse_BindingResponse = {
+    data: {
+      estimator_id: string;
+      id: string;
+      inputs_mapping: Record<string, unknown>;
+      map_over_step?: (string | null) | undefined;
+      outputs_reduce_strategy: Record<string, unknown>;
+    };
+    success: boolean;
+  };
+  export type EstimatorParameterTypeDto =
+    | { kind: "number" }
+    | { kind: "boolean" }
+    | { kind: "product"; label_filter?: (string | null) | undefined };
+  export type InputResponse = {
+    description: string;
+    id: string;
+    key: string;
+    parameter_type: EstimatorParameterTypeDto;
+  };
+  export type OutputResponse = { description: string; expression: string; id: string; key: string };
   export type EstimatorResponse = {
     description: string;
     flow_id: string;
     id: string;
+    inputs: Array<InputResponse>;
     name: string;
-    variables: Array<VariableResponse>;
+    outputs: Array<OutputResponse>;
   };
   export type ApiResponse_EstimatorListResponse = { data: { estimators: Array<EstimatorResponse> }; success: boolean };
   export type ApiResponse_EstimatorResponse = {
-    data: { description: string; flow_id: string; id: string; name: string; variables: Array<VariableResponse> };
+    data: {
+      description: string;
+      flow_id: string;
+      id: string;
+      inputs: Array<InputResponse>;
+      name: string;
+      outputs: Array<OutputResponse>;
+    };
     success: boolean;
   };
   export type ApiResponse_EvaluateFlowResponse = {
@@ -53,7 +95,15 @@ export namespace Schemas {
     data: { description: string; id: string; name: string; steps: Array<StepResponse> };
     success: boolean;
   };
+  export type ApiResponse_InputResponse = {
+    data: { description: string; id: string; key: string; parameter_type: EstimatorParameterTypeDto };
+    success: boolean;
+  };
   export type ApiResponse_MessageResponse = { data: { message: string }; success: boolean };
+  export type ApiResponse_OutputResponse = {
+    data: { description: string; expression: string; id: string; key: string };
+    success: boolean;
+  };
   export type ApiResponse_StepResponse = {
     data: {
       description: string;
@@ -68,13 +118,44 @@ export namespace Schemas {
     };
     success: boolean;
   };
-  export type ApiResponse_VariableResponse = {
-    data: { description: string; expression: string; id: string; name: string };
+  export type StepIterationDto = { answers: Record<string, unknown> };
+  export type SubmissionResponse = {
+    answers: Record<string, Array<StepIterationDto>>;
+    flow_id: string;
+    id: string;
+    submitted_at: string;
+    user_id: string;
+  };
+  export type ApiResponse_SubmissionListResponse = {
+    data: { submissions: Array<SubmissionResponse> };
     success: boolean;
+  };
+  export type ApiResponse_SubmissionResponse = {
+    data: {
+      answers: Record<string, Array<StepIterationDto>>;
+      flow_id: string;
+      id: string;
+      submitted_at: string;
+      user_id: string;
+    };
+    success: boolean;
+  };
+  export type BindingListResponse = { bindings: Array<BindingResponse> };
+  export type CreateBindingRequest = {
+    estimator_id: string;
+    inputs_mapping: Record<string, unknown>;
+    map_over_step?: (string | null) | undefined;
+    outputs_reduce_strategy?: Record<string, unknown> | undefined;
   };
   export type CreateEstimatorRequest = { name: string };
   export type CreateFieldRequest = { config: FieldConfigDto; key: string; label: string };
   export type CreateFlowRequest = { description?: (string | null) | undefined; name: string };
+  export type CreateInputRequest = {
+    description?: (string | null) | undefined;
+    key: string;
+    parameter_type: EstimatorParameterTypeDto;
+  };
+  export type CreateOutputRequest = { description?: (string | null) | undefined; expression: string; key: string };
   export type CreateStepRequest = {
     description?: (string | null) | undefined;
     is_repeatable?: (boolean | null) | undefined;
@@ -83,7 +164,6 @@ export namespace Schemas {
     repeat_label?: (string | null) | undefined;
     title: string;
   };
-  export type CreateVariableRequest = { description?: (string | null) | undefined; expression: string; name: string };
   export type EstimatorListResponse = { estimators: Array<EstimatorResponse> };
   export type EvaluateFlowResponse = {
     flat_results: Record<string, number>;
@@ -106,6 +186,13 @@ export namespace Schemas {
     target_step_id: string | null;
   }>;
   export type ReorderStepRequest = Partial<{ after_id: string | null; before_id: string | null }>;
+  export type SubmissionListResponse = { submissions: Array<SubmissionResponse> };
+  export type SubmitAnswersRequest = { answers: Record<string, Array<StepIterationDto>>; user_id: string };
+  export type UpdateBindingRequest = Partial<{
+    inputs_mapping: Record<string, unknown> | null;
+    map_over_step: string | null;
+    outputs_reduce_strategy: Record<string, unknown> | null;
+  }>;
   export type UpdateEstimatorRequest = Partial<{ description: string | null; name: string | null }>;
   export type UpdateFieldConfigRequest = Partial<{
     config: null | FieldConfigDto;
@@ -114,6 +201,16 @@ export namespace Schemas {
     label: string | null;
   }>;
   export type UpdateFlowMetadataRequest = { description?: (string | null) | undefined; name: string };
+  export type UpdateInputRequest = Partial<{
+    description: string | null;
+    key: string | null;
+    parameter_type: null | EstimatorParameterTypeDto;
+  }>;
+  export type UpdateOutputRequest = Partial<{
+    description: string | null;
+    expression: string | null;
+    key: string | null;
+  }>;
   export type UpdateStepMetadataRequest = Partial<{
     description: string | null;
     is_repeatable: boolean | null;
@@ -121,11 +218,6 @@ export namespace Schemas {
     min_repeats: number | null;
     repeat_label: string | null;
     title: string | null;
-  }>;
-  export type UpdateVariableRequest = Partial<{
-    description: string | null;
-    expression: string | null;
-    name: string | null;
   }>;
 
   // </Schemas>
@@ -185,16 +277,67 @@ export namespace Endpoints {
     };
     responses: { 200: Schemas.EvaluateResponse; 400: unknown; 404: unknown };
   };
-  export type post_Add_variable = {
+  export type post_Add_input = {
     method: "POST";
-    path: "/api/v1/estimators/{estimator_id}/variables";
+    path: "/api/v1/estimators/{estimator_id}/inputs";
     requestFormat: "json";
     parameters: {
       path: { estimator_id: string };
 
-      body: Schemas.CreateVariableRequest;
+      body: Schemas.CreateInputRequest;
     };
-    responses: { 201: Schemas.VariableResponse; 400: unknown; 404: unknown };
+    responses: { 201: Schemas.InputResponse; 400: unknown; 404: unknown };
+  };
+  export type put_Update_input = {
+    method: "PUT";
+    path: "/api/v1/estimators/{estimator_id}/inputs/{input_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { estimator_id: string; input_id: string };
+
+      body: Schemas.UpdateInputRequest;
+    };
+    responses: { 200: Schemas.InputResponse; 400: unknown; 404: unknown };
+  };
+  export type delete_Remove_input = {
+    method: "DELETE";
+    path: "/api/v1/estimators/{estimator_id}/inputs/{input_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { estimator_id: string; input_id: string };
+    };
+    responses: { 200: Schemas.MessageResponse; 404: unknown };
+  };
+  export type post_Add_output = {
+    method: "POST";
+    path: "/api/v1/estimators/{estimator_id}/outputs";
+    requestFormat: "json";
+    parameters: {
+      path: { estimator_id: string };
+
+      body: Schemas.CreateOutputRequest;
+    };
+    responses: { 201: Schemas.OutputResponse; 400: unknown; 404: unknown };
+  };
+  export type put_Update_output = {
+    method: "PUT";
+    path: "/api/v1/estimators/{estimator_id}/outputs/{output_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { estimator_id: string; output_id: string };
+
+      body: Schemas.UpdateOutputRequest;
+    };
+    responses: { 200: Schemas.OutputResponse; 400: unknown; 404: unknown };
+  };
+  export type delete_Remove_output = {
+    method: "DELETE";
+    path: "/api/v1/estimators/{estimator_id}/outputs/{output_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { estimator_id: string; output_id: string };
+    };
+    responses: { 200: Schemas.MessageResponse; 404: unknown };
   };
   export type get_List_flows = {
     method: "GET";
@@ -314,6 +457,46 @@ export namespace Endpoints {
     };
     responses: { 200: Schemas.MessageResponse; 404: unknown };
   };
+  export type get_List_bindings = {
+    method: "GET";
+    path: "/api/v1/flows/{flow_id}/bindings";
+    requestFormat: "json";
+    parameters: {
+      path: { flow_id: string };
+    };
+    responses: { 200: Schemas.BindingListResponse };
+  };
+  export type post_Add_binding = {
+    method: "POST";
+    path: "/api/v1/flows/{flow_id}/bindings";
+    requestFormat: "json";
+    parameters: {
+      path: { flow_id: string };
+
+      body: Schemas.CreateBindingRequest;
+    };
+    responses: { 201: Schemas.BindingResponse; 400: unknown; 404: unknown };
+  };
+  export type put_Update_binding = {
+    method: "PUT";
+    path: "/api/v1/flows/{flow_id}/bindings/{binding_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { flow_id: string; binding_id: string };
+
+      body: Schemas.UpdateBindingRequest;
+    };
+    responses: { 200: Schemas.BindingResponse; 400: unknown; 404: unknown };
+  };
+  export type delete_Remove_binding = {
+    method: "DELETE";
+    path: "/api/v1/flows/{flow_id}/bindings/{binding_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { flow_id: string; binding_id: string };
+    };
+    responses: { 200: Schemas.MessageResponse; 404: unknown; 409: unknown };
+  };
   export type get_List_estimators = {
     method: "GET";
     path: "/api/v1/flows/{flow_id}/estimators";
@@ -356,25 +539,34 @@ export namespace Endpoints {
     };
     responses: { 201: Schemas.StepResponse; 400: unknown; 404: unknown };
   };
-  export type put_Update_variable = {
-    method: "PUT";
-    path: "/api/v1/variables/{variable_id}";
+  export type get_List_submissions_for_flow = {
+    method: "GET";
+    path: "/api/v1/flows/{flow_id}/submissions";
     requestFormat: "json";
     parameters: {
-      path: { variable_id: string };
-
-      body: Schemas.UpdateVariableRequest;
+      path: { flow_id: string };
     };
-    responses: { 200: Schemas.VariableResponse; 400: unknown; 404: unknown };
+    responses: { 200: Schemas.SubmissionListResponse };
   };
-  export type delete_Remove_variable = {
-    method: "DELETE";
-    path: "/api/v1/variables/{variable_id}";
+  export type post_Submit_answers = {
+    method: "POST";
+    path: "/api/v1/flows/{flow_id}/submissions";
     requestFormat: "json";
     parameters: {
-      path: { variable_id: string };
+      path: { flow_id: string };
+
+      body: Schemas.SubmitAnswersRequest;
     };
-    responses: { 200: Schemas.MessageResponse; 404: unknown };
+    responses: { 201: Schemas.SubmissionResponse; 400: unknown; 404: unknown };
+  };
+  export type get_Get_submission_by_id = {
+    method: "GET";
+    path: "/api/v1/submissions/{submission_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { submission_id: string };
+    };
+    responses: { 200: Schemas.SubmissionResponse; 404: unknown };
   };
 
   // </Endpoints>
@@ -386,33 +578,43 @@ export type EndpointByMethod = {
     "/api/v1/estimators/{estimator_id}": Endpoints.get_Get_estimator;
     "/api/v1/flows": Endpoints.get_List_flows;
     "/api/v1/flows/{flow_id}": Endpoints.get_Get_flow;
+    "/api/v1/flows/{flow_id}/bindings": Endpoints.get_List_bindings;
     "/api/v1/flows/{flow_id}/estimators": Endpoints.get_List_estimators;
+    "/api/v1/flows/{flow_id}/submissions": Endpoints.get_List_submissions_for_flow;
+    "/api/v1/submissions/{submission_id}": Endpoints.get_Get_submission_by_id;
   };
   put: {
     "/api/v1/estimators/{estimator_id}": Endpoints.put_Update_estimator;
+    "/api/v1/estimators/{estimator_id}/inputs/{input_id}": Endpoints.put_Update_input;
+    "/api/v1/estimators/{estimator_id}/outputs/{output_id}": Endpoints.put_Update_output;
     "/api/v1/flows/fields/{field_id}": Endpoints.put_Update_field_config;
     "/api/v1/flows/fields/{field_id}/move": Endpoints.put_Move_field;
     "/api/v1/flows/steps/{step_id}": Endpoints.put_Update_step_metadata;
     "/api/v1/flows/steps/{step_id}/reorder": Endpoints.put_Reorder_step;
     "/api/v1/flows/{flow_id}": Endpoints.put_Update_flow_metadata;
-    "/api/v1/variables/{variable_id}": Endpoints.put_Update_variable;
+    "/api/v1/flows/{flow_id}/bindings/{binding_id}": Endpoints.put_Update_binding;
   };
   delete: {
     "/api/v1/estimators/{estimator_id}": Endpoints.delete_Delete_estimator;
+    "/api/v1/estimators/{estimator_id}/inputs/{input_id}": Endpoints.delete_Remove_input;
+    "/api/v1/estimators/{estimator_id}/outputs/{output_id}": Endpoints.delete_Remove_output;
     "/api/v1/flows/fields/{field_id}": Endpoints.delete_Remove_field;
     "/api/v1/flows/steps/{step_id}": Endpoints.delete_Remove_step;
     "/api/v1/flows/{flow_id}": Endpoints.delete_Delete_flow;
-    "/api/v1/variables/{variable_id}": Endpoints.delete_Remove_variable;
+    "/api/v1/flows/{flow_id}/bindings/{binding_id}": Endpoints.delete_Remove_binding;
   };
   post: {
     "/api/v1/estimators/{estimator_id}/evaluate": Endpoints.post_Evaluate;
     "/api/v1/estimators/{estimator_id}/evaluate-submission": Endpoints.post_Evaluate_submission;
-    "/api/v1/estimators/{estimator_id}/variables": Endpoints.post_Add_variable;
+    "/api/v1/estimators/{estimator_id}/inputs": Endpoints.post_Add_input;
+    "/api/v1/estimators/{estimator_id}/outputs": Endpoints.post_Add_output;
     "/api/v1/flows": Endpoints.post_Create_flow;
     "/api/v1/flows/steps/{step_id}/fields": Endpoints.post_Add_field;
+    "/api/v1/flows/{flow_id}/bindings": Endpoints.post_Add_binding;
     "/api/v1/flows/{flow_id}/estimators": Endpoints.post_Create_estimator;
     "/api/v1/flows/{flow_id}/evaluate-all": Endpoints.post_Evaluate_flow;
     "/api/v1/flows/{flow_id}/steps": Endpoints.post_Add_step;
+    "/api/v1/flows/{flow_id}/submissions": Endpoints.post_Submit_answers;
   };
 };
 

--- a/apps/ferrisquote-webapp/src/api/estimators.api.ts
+++ b/apps/ferrisquote-webapp/src/api/estimators.api.ts
@@ -65,65 +65,72 @@ export const useDeleteEstimator = (flowId: string) => {
   })
 }
 
-// ─── Variables ────────────────────────────────────────────────────────────────
+// ─── Shared cache invalidator for signature mutations ─────────────────────────
 
-export const useAddVariable = (flowId: string, estimatorId: string) => {
+function invalidateEstimator(qc: ReturnType<typeof useQueryClient>, flowId: string, estimatorId: string) {
+  return Promise.all([
+    qc.invalidateQueries({
+      queryKey: window.tanstackApi.get("/api/v1/flows/{flow_id}/estimators", {
+        path: { flow_id: flowId },
+      }).queryKey,
+    }),
+    qc.invalidateQueries({
+      queryKey: window.tanstackApi.get("/api/v1/estimators/{estimator_id}", {
+        path: { estimator_id: estimatorId },
+      }).queryKey,
+    }),
+  ])
+}
+
+// ─── Inputs ───────────────────────────────────────────────────────────────────
+
+export const useAddInput = (flowId: string, estimatorId: string) => {
   const qc = useQueryClient()
   return useMutation({
-    ...window.tanstackApi.mutation("post", "/api/v1/estimators/{estimator_id}/variables").mutationOptions,
-    onSuccess: () =>
-      Promise.all([
-        qc.invalidateQueries({
-          queryKey: window.tanstackApi.get("/api/v1/flows/{flow_id}/estimators", {
-            path: { flow_id: flowId },
-          }).queryKey,
-        }),
-        qc.invalidateQueries({
-          queryKey: window.tanstackApi.get("/api/v1/estimators/{estimator_id}", {
-            path: { estimator_id: estimatorId },
-          }).queryKey,
-        }),
-      ]),
+    ...window.tanstackApi.mutation("post", "/api/v1/estimators/{estimator_id}/inputs").mutationOptions,
+    onSuccess: () => invalidateEstimator(qc, flowId, estimatorId),
   })
 }
 
-export const useUpdateVariable = (flowId: string, estimatorId: string) => {
+export const useUpdateInput = (flowId: string, estimatorId: string) => {
   const qc = useQueryClient()
   return useMutation({
-    ...window.tanstackApi.mutation("put", "/api/v1/variables/{variable_id}").mutationOptions,
-    onSuccess: () =>
-      Promise.all([
-        qc.invalidateQueries({
-          queryKey: window.tanstackApi.get("/api/v1/flows/{flow_id}/estimators", {
-            path: { flow_id: flowId },
-          }).queryKey,
-        }),
-        qc.invalidateQueries({
-          queryKey: window.tanstackApi.get("/api/v1/estimators/{estimator_id}", {
-            path: { estimator_id: estimatorId },
-          }).queryKey,
-        }),
-      ]),
+    ...window.tanstackApi.mutation("put", "/api/v1/estimators/{estimator_id}/inputs/{input_id}").mutationOptions,
+    onSuccess: () => invalidateEstimator(qc, flowId, estimatorId),
   })
 }
 
-export const useRemoveVariable = (flowId: string, estimatorId: string) => {
+export const useRemoveInput = (flowId: string, estimatorId: string) => {
   const qc = useQueryClient()
   return useMutation({
-    ...window.tanstackApi.mutation("delete", "/api/v1/variables/{variable_id}").mutationOptions,
-    onSuccess: () =>
-      Promise.all([
-        qc.invalidateQueries({
-          queryKey: window.tanstackApi.get("/api/v1/flows/{flow_id}/estimators", {
-            path: { flow_id: flowId },
-          }).queryKey,
-        }),
-        qc.invalidateQueries({
-          queryKey: window.tanstackApi.get("/api/v1/estimators/{estimator_id}", {
-            path: { estimator_id: estimatorId },
-          }).queryKey,
-        }),
-      ]),
+    ...window.tanstackApi.mutation("delete", "/api/v1/estimators/{estimator_id}/inputs/{input_id}").mutationOptions,
+    onSuccess: () => invalidateEstimator(qc, flowId, estimatorId),
+  })
+}
+
+// ─── Outputs ──────────────────────────────────────────────────────────────────
+
+export const useAddOutput = (flowId: string, estimatorId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation("post", "/api/v1/estimators/{estimator_id}/outputs").mutationOptions,
+    onSuccess: () => invalidateEstimator(qc, flowId, estimatorId),
+  })
+}
+
+export const useUpdateOutput = (flowId: string, estimatorId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation("put", "/api/v1/estimators/{estimator_id}/outputs/{output_id}").mutationOptions,
+    onSuccess: () => invalidateEstimator(qc, flowId, estimatorId),
+  })
+}
+
+export const useRemoveOutput = (flowId: string, estimatorId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation("delete", "/api/v1/estimators/{estimator_id}/outputs/{output_id}").mutationOptions,
+    onSuccess: () => invalidateEstimator(qc, flowId, estimatorId),
   })
 }
 

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/estimator-draft-store.ts
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/estimator-draft-store.ts
@@ -4,8 +4,8 @@ import type { Schemas } from "@/api/api.client"
 /**
  * Ephemeral draft state for the estimator currently being edited in the
  * sidenav. Shared via Zustand so the canvas can overlay uncommitted edits
- * (variable adds/deletes/patches, name, description) onto the server data
- * before building the graph — the map stays "live" as the user types.
+ * (input/output adds, deletes, patches + name/description) onto the server
+ * data before building the graph.
  *
  * On Save / Cancel / estimator switch, the panel calls `clear()`.
  */
@@ -16,18 +16,33 @@ export type EstimatorDraftState = {
   estimatorId: string | null
   nameDraft: string | null
   descDraft: string | null
-  variableEdits: Record<string, Partial<Schemas.VariableResponse>>
-  pendingAdds: Schemas.VariableResponse[]
-  pendingDeletes: Set<string>
+
+  // Inputs
+  inputEdits: Record<string, Partial<Schemas.InputResponse>>
+  pendingInputAdds: Schemas.InputResponse[]
+  pendingInputDeletes: Set<string>
+
+  // Outputs
+  outputEdits: Record<string, Partial<Schemas.OutputResponse>>
+  pendingOutputAdds: Schemas.OutputResponse[]
+  pendingOutputDeletes: Set<string>
 
   setActive: (id: string | null) => void
   setName: (name: string | null) => void
   setDesc: (desc: string | null) => void
-  patchVariable: (id: string, patch: Partial<Schemas.VariableResponse>) => void
-  dropVariableEdit: (id: string) => void
-  addPending: (v: Schemas.VariableResponse) => void
-  removePending: (id: string) => void
-  markDelete: (id: string) => void
+
+  patchInput: (id: string, patch: Partial<Schemas.InputResponse>) => void
+  dropInputEdit: (id: string) => void
+  addPendingInput: (v: Schemas.InputResponse) => void
+  removePendingInput: (id: string) => void
+  markInputDelete: (id: string) => void
+
+  patchOutput: (id: string, patch: Partial<Schemas.OutputResponse>) => void
+  dropOutputEdit: (id: string) => void
+  addPendingOutput: (v: Schemas.OutputResponse) => void
+  removePendingOutput: (id: string) => void
+  markOutputDelete: (id: string) => void
+
   clear: () => void
 }
 
@@ -35,45 +50,68 @@ const empty = {
   estimatorId: null,
   nameDraft: null,
   descDraft: null,
-  variableEdits: {},
-  pendingAdds: [],
-  pendingDeletes: new Set<string>(),
+  inputEdits: {},
+  pendingInputAdds: [],
+  pendingInputDeletes: new Set<string>(),
+  outputEdits: {},
+  pendingOutputAdds: [],
+  pendingOutputDeletes: new Set<string>(),
 }
 
 export const useEstimatorDraftStore = create<EstimatorDraftState>((set) => ({
   ...empty,
 
   setActive: (id) =>
-    set((s) =>
-      s.estimatorId === id ? s : { ...empty, estimatorId: id },
-    ),
+    set((s) => (s.estimatorId === id ? s : { ...empty, estimatorId: id })),
   setName: (name) => set({ nameDraft: name }),
   setDesc: (desc) => set({ descDraft: desc }),
-  patchVariable: (id, patch) =>
+
+  patchInput: (id, patch) =>
     set((s) => ({
-      variableEdits: {
-        ...s.variableEdits,
-        [id]: { ...(s.variableEdits[id] ?? {}), ...patch },
-      },
+      inputEdits: { ...s.inputEdits, [id]: { ...(s.inputEdits[id] ?? {}), ...patch } },
     })),
-  dropVariableEdit: (id) =>
+  dropInputEdit: (id) =>
     set((s) => {
-      if (!(id in s.variableEdits)) return s
-      const next = { ...s.variableEdits }
+      if (!(id in s.inputEdits)) return s
+      const next = { ...s.inputEdits }
       delete next[id]
-      return { variableEdits: next }
+      return { inputEdits: next }
     }),
-  addPending: (v) => set((s) => ({ pendingAdds: [...s.pendingAdds, v] })),
-  removePending: (id) =>
-    set((s) => ({ pendingAdds: s.pendingAdds.filter((v) => v.id !== id) })),
-  markDelete: (id) =>
+  addPendingInput: (v) => set((s) => ({ pendingInputAdds: [...s.pendingInputAdds, v] })),
+  removePendingInput: (id) =>
+    set((s) => ({ pendingInputAdds: s.pendingInputAdds.filter((v) => v.id !== id) })),
+  markInputDelete: (id) =>
     set((s) => {
-      const next = new Set(s.pendingDeletes)
+      const next = new Set(s.pendingInputDeletes)
       next.add(id)
-      const edits = { ...s.variableEdits }
+      const edits = { ...s.inputEdits }
       delete edits[id]
-      return { pendingDeletes: next, variableEdits: edits }
+      return { pendingInputDeletes: next, inputEdits: edits }
     }),
+
+  patchOutput: (id, patch) =>
+    set((s) => ({
+      outputEdits: { ...s.outputEdits, [id]: { ...(s.outputEdits[id] ?? {}), ...patch } },
+    })),
+  dropOutputEdit: (id) =>
+    set((s) => {
+      if (!(id in s.outputEdits)) return s
+      const next = { ...s.outputEdits }
+      delete next[id]
+      return { outputEdits: next }
+    }),
+  addPendingOutput: (v) => set((s) => ({ pendingOutputAdds: [...s.pendingOutputAdds, v] })),
+  removePendingOutput: (id) =>
+    set((s) => ({ pendingOutputAdds: s.pendingOutputAdds.filter((v) => v.id !== id) })),
+  markOutputDelete: (id) =>
+    set((s) => {
+      const next = new Set(s.pendingOutputDeletes)
+      next.add(id)
+      const edits = { ...s.outputEdits }
+      delete edits[id]
+      return { pendingOutputDeletes: next, outputEdits: edits }
+    }),
+
   clear: () => set({ ...empty }),
 }))
 
@@ -87,11 +125,18 @@ export function overlayEstimators(
   return estimators.map((e) => {
     if (e.id !== drafts.estimatorId) return e
 
-    const variables: Schemas.VariableResponse[] = [
-      ...e.variables
-        .filter((v) => !drafts.pendingDeletes.has(v.id))
-        .map((v) => ({ ...v, ...(drafts.variableEdits[v.id] ?? {}) })),
-      ...drafts.pendingAdds,
+    const inputs: Schemas.InputResponse[] = [
+      ...e.inputs
+        .filter((v) => !drafts.pendingInputDeletes.has(v.id))
+        .map((v) => ({ ...v, ...(drafts.inputEdits[v.id] ?? {}) })),
+      ...drafts.pendingInputAdds,
+    ]
+
+    const outputs: Schemas.OutputResponse[] = [
+      ...e.outputs
+        .filter((v) => !drafts.pendingOutputDeletes.has(v.id))
+        .map((v) => ({ ...v, ...(drafts.outputEdits[v.id] ?? {}) })),
+      ...drafts.pendingOutputAdds,
     ]
 
     const name =
@@ -100,6 +145,6 @@ export function overlayEstimators(
         : e.name
     const description = drafts.descDraft != null ? drafts.descDraft : e.description
 
-    return { ...e, name, description, variables }
+    return { ...e, name, description, inputs, outputs }
   })
 }

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
@@ -559,9 +559,17 @@ function FlowCanvasImpl({ flowId, panelState, setPanelState }: Props) {
     }
 
     if (node.type !== "stepNode") return
+    // Toggle expand when the step is already selected in the panel; otherwise
+    // select + expand. Keeps a second click on the same step as "collapse".
+    const alreadySelected =
+      panelState?.mode === "step-details" && panelState.stepId === node.id
     setExpandedStepIds((prev) => {
       const next = new Set(prev)
-      next.add(node.id)
+      if (alreadySelected && next.has(node.id)) {
+        next.delete(node.id)
+      } else {
+        next.add(node.id)
+      }
       return next
     })
     setPanelState({ mode: "step-details", stepId: node.id })

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
@@ -188,7 +188,7 @@ function buildGraph(
       })
     }
 
-    if (isExpanded && step.fields.length > 0) {
+    if (step.fields.length > 0) {
       const totalFieldsHeight =
         step.fields.length * (FIELD_NODE_HEIGHT + FIELD_NODE_GAP) - FIELD_NODE_GAP
       const hueStep = step.fields.length > 1 ? 200 / (step.fields.length - 1) : 0
@@ -196,10 +196,13 @@ function buildGraph(
       step.fields.forEach((field, j) => {
         const fieldNodeId = `field-${field.id}`
         const targetY = stepY + j * (FIELD_NODE_HEIGHT + FIELD_NODE_GAP)
-        const fieldY = targetY
-        const xOffset = FIELD_X_OFFSET
-        const opacity = 1
-        const pointerEvents = "auto" as const
+        // When collapsed, fields snap back under the step and fade out —
+        // keeps them in the DOM so React Flow can animate opacity + position
+        // instead of mounting/unmounting.
+        const fieldY = isExpanded ? targetY : stepY
+        const xOffset = isExpanded ? FIELD_X_OFFSET : 0
+        const opacity = isExpanded ? 1 : 0
+        const pointerEvents = isExpanded ? ("auto" as const) : ("none" as const)
         const color = `hsl(${28 + j * hueStep}, 85%, 55%)`
 
         const fieldNode: Node<FieldNodeData> = {
@@ -234,13 +237,19 @@ function buildGraph(
             strokeWidth: 1.5,
             stroke: color,
             opacity,
-            transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+            // Fade edges in slightly after the node position settles when
+            // expanding; snap-out fast when collapsing.
+            transition: isExpanded
+              ? "opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.15s"
+              : "opacity 0.1s ease-out 0s",
           },
         })
       })
 
-      const extraSpace = Math.max(0, totalFieldsHeight - STEP_NODE_HEIGHT)
-      yOffset += extraSpace + STEP_NODE_GAP
+      if (isExpanded) {
+        const extraSpace = Math.max(0, totalFieldsHeight - STEP_NODE_HEIGHT)
+        yOffset += extraSpace + STEP_NODE_GAP
+      }
     }
   }
 

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
@@ -331,14 +331,16 @@ function buildGraph(
     const x = ESTIMATOR_X_OFFSET + d * ESTIMATOR_X_STEP
     let y = 0
     for (const est of estsAtDepth) {
-      const varCount = est.variables.length
-      const nodeHeight = 54 + Math.max(varCount, 1) * 24
+      const inputCount = est.inputs.length
+      const outputCount = est.outputs.length
+      const nodeHeight =
+        54 + Math.max(inputCount, 1) * 24 + 24 + Math.max(outputCount, 1) * 24
       const estimatorNodeId = `estimator-${est.id}`
       const color = estIdToColor.get(est.id) ?? "hsl(335, 70%, 55%)"
 
-      const displayVariables = est.variables.map((v) => ({
-        ...v,
-        expression: idsToNames(v.expression, estimatorsIndex),
+      const displayOutputs = est.outputs.map((o) => ({
+        ...o,
+        expression: idsToNames(o.expression, estimatorsIndex),
       }))
 
       const estNode: Node<EstimatorNodeData> = {
@@ -352,7 +354,8 @@ function buildGraph(
         data: {
           name: est.name,
           description: est.description,
-          variables: displayVariables,
+          inputs: est.inputs,
+          outputs: displayOutputs,
           color,
           onDelete: () => onDeleteEstimator(est.id),
         },
@@ -362,33 +365,34 @@ function buildGraph(
     }
   }
 
-  const estVariableNameToId = new Map<string, Map<string, string>>()
+  // Build per-estimator lookup: output key → output id (for cross-ref edges)
+  const estOutputKeyToId = new Map<string, Map<string, string>>()
   for (const est of estimators) {
     const m = new Map<string, string>()
-    for (const v of est.variables) m.set(v.name, v.id)
-    estVariableNameToId.set(est.id, m)
+    for (const o of est.outputs) m.set(o.key, o.id)
+    estOutputKeyToId.set(est.id, m)
   }
 
   for (const est of estimators) {
     const estimatorNodeId = `estimator-${est.id}`
     const estColor = estIdToColor.get(est.id) ?? "hsl(330, 75%, 58%)"
 
-    for (const v of est.variables) {
-      const refs = extractExprRefs(v.expression)
+    for (const o of est.outputs) {
+      const refs = extractExprRefs(o.expression)
       for (const ref of refs) {
         if (ref.type === "cross") {
           const sourceNodeId = estIdToNodeId.get(ref.estimatorId)
           if (sourceNodeId && sourceNodeId !== estimatorNodeId) {
-            const sourceVarId = estVariableNameToId
+            const sourceOutputId = estOutputKeyToId
               .get(ref.estimatorId)
               ?.get(ref.variableName)
-            const sourceHandle = sourceVarId ? `source-${sourceVarId}` : "default-source"
+            const sourceHandle = sourceOutputId ? `source-${sourceOutputId}` : "default-source"
             edges.push({
-              id: `e-cross-${est.id}-${v.id}-${ref.estimatorId}.${ref.variableName}`,
+              id: `e-cross-${est.id}-${o.id}-${ref.estimatorId}.${ref.variableName}`,
               source: sourceNodeId,
               sourceHandle,
               target: estimatorNodeId,
-              targetHandle: `target-${v.id}`,
+              targetHandle: `target-${o.id}`,
               type: "smoothstep",
               animated: true,
               style: {
@@ -411,11 +415,11 @@ function buildGraph(
           const isAgg = ref.aggregation !== false
 
           edges.push({
-            id: `e-est-${est.id}-${v.id}-${ref.key}-${ref.aggregation || "direct"}`,
+            id: `e-est-${est.id}-${o.id}-${ref.key}-${ref.aggregation || "direct"}`,
             source: sourceId,
             sourceHandle: "right",
             target: estimatorNodeId,
-            targetHandle: `target-${v.id}`,
+            targetHandle: `target-${o.id}`,
             type: "smoothstep",
             animated: isAgg,
             style: {

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
@@ -275,8 +275,8 @@ function buildGraph(
   const estCrossDeps = new Map<string, Set<string>>()
   for (const est of estimators) {
     const deps = new Set<string>()
-    for (const v of est.variables) {
-      for (const ref of extractExprRefs(v.expression)) {
+    for (const o of est.outputs) {
+      for (const ref of extractExprRefs(o.expression)) {
         if (ref.type === "cross" && ref.estimatorId !== est.id) {
           deps.add(ref.estimatorId)
         }

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-edit-panel.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-edit-panel.tsx
@@ -65,7 +65,7 @@ function FlowEditPanelImpl({ flowId, state, onClose, setPanelState }: Props) {
     flow?.steps.flatMap((s) => s.fields.map((f) => f.key)) ?? []
   const otherEstimators = estimators
     .filter((e) => e.id !== estimator?.id)
-    .map((e) => ({ id: e.id, name: e.name, variables: e.variables.map((v) => v.name) }))
+    .map((e) => ({ id: e.id, name: e.name, outputs: e.outputs.map((o) => o.key) }))
   const estimatorsIndex = estimators.map((e) => ({ id: e.id, name: e.name }))
 
   // Form submit handlers (local to the panel)

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-edit-panel.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-edit-panel.tsx
@@ -60,9 +60,15 @@ function FlowEditPanelImpl({ flowId, state, onClose, setPanelState }: Props) {
       ? estimators.find((e) => e.id === state.estimatorId) ?? null
       : null
 
-  // Autocomplete data
+  // Autocomplete data: only numeric fields make sense as operands in an
+  // estimator expression (text/date/select/boolean are not directly usable
+  // as a number — even a boolean answer isn't implicitly coerced on the
+  // backend for bare `@field` references).
   const availableFieldKeys =
-    flow?.steps.flatMap((s) => s.fields.map((f) => f.key)) ?? []
+    flow?.steps
+      .flatMap((s) => s.fields)
+      .filter((f) => f.config.type === "number")
+      .map((f) => f.key) ?? []
   const otherEstimators = estimators
     .filter((e) => e.id !== estimator?.id)
     .map((e) => ({ id: e.id, name: e.name, outputs: e.outputs.map((o) => o.key) }))

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
@@ -3,10 +3,13 @@ import { Loader2, Plus, X } from "lucide-react"
 import { toast } from "sonner"
 import type { Schemas } from "@/api/api.client"
 import {
-  useAddVariable,
-  useRemoveVariable,
+  useAddInput,
+  useAddOutput,
+  useRemoveInput,
+  useRemoveOutput,
   useUpdateEstimator,
-  useUpdateVariable,
+  useUpdateInput,
+  useUpdateOutput,
 } from "@/api/estimators.api"
 import { type EstimatorIndex } from "@/pages/flows/lib/expression-refs"
 import {
@@ -17,7 +20,8 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { VariableCard } from "./variable-card"
+import { InputCard } from "./input-card"
+import { OutputCard } from "./output-card"
 
 const ROSE = "hsl(330, 80%, 60%)"
 
@@ -32,19 +36,16 @@ export function EstimatorDetailsPanel({
   estimator: Schemas.EstimatorResponse
   flowId: string
   availableFieldKeys: string[]
-  otherEstimators: Array<{ id: string; name: string; variables: string[] }>
+  otherEstimators: Array<{ id: string; name: string; outputs: string[] }>
   estimatorsIndex: EstimatorIndex
   onClose: () => void
 }) {
   const [editingName, setEditingName] = useState(false)
 
-  // Zustand draft store — shared with the canvas so the graph reflects
-  // uncommitted edits live. Reset whenever the estimator identity changes.
   const drafts = useEstimatorDraftStore()
 
   useEffect(() => {
     drafts.setActive(estimator.id)
-    // Cleanup when unmounting / switching estimator
     return () => {
       if (useEstimatorDraftStore.getState().estimatorId === estimator.id) {
         drafts.clear()
@@ -53,49 +54,67 @@ export function EstimatorDetailsPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [estimator.id])
 
-  // Also resync when server values change under our feet (e.g. save just
-  // landed and cache refreshed) — only if no user edits are pending.
   useEffect(() => {
     setEditingName(false)
   }, [estimator.id, estimator.name, estimator.description])
 
   const updateEstimator = useUpdateEstimator(flowId, estimator.id)
-  const addVariable = useAddVariable(flowId, estimator.id)
-  const updateVariable = useUpdateVariable(flowId, estimator.id)
-  const removeVariable = useRemoveVariable(flowId, estimator.id)
+  const addInput = useAddInput(flowId, estimator.id)
+  const updateInput = useUpdateInput(flowId, estimator.id)
+  const removeInput = useRemoveInput(flowId, estimator.id)
+  const addOutput = useAddOutput(flowId, estimator.id)
+  const updateOutput = useUpdateOutput(flowId, estimator.id)
+  const removeOutput = useRemoveOutput(flowId, estimator.id)
 
-  // Display values: use draft when present, fall back to server
   const nameDisplay =
     drafts.nameDraft != null ? drafts.nameDraft : estimator.name.replace(/_/g, " ")
   const descDisplay = drafts.descDraft != null ? drafts.descDraft : estimator.description
 
-  // Effective variables (server + pending adds, minus pending deletes, with edits overlaid)
-  const effectiveVariables: Schemas.VariableResponse[] = [
-    ...estimator.variables
-      .filter((v) => !drafts.pendingDeletes.has(v.id))
+  const effectiveInputs: Schemas.InputResponse[] = [
+    ...estimator.inputs
+      .filter((v) => !drafts.pendingInputDeletes.has(v.id))
       .map((v) => {
-        const patch = drafts.variableEdits[v.id]
+        const patch = drafts.inputEdits[v.id]
         return patch ? { ...v, ...patch } : v
       }),
-    ...drafts.pendingAdds,
+    ...drafts.pendingInputAdds,
   ]
 
-  // Validation
+  const effectiveOutputs: Schemas.OutputResponse[] = [
+    ...estimator.outputs
+      .filter((v) => !drafts.pendingOutputDeletes.has(v.id))
+      .map((v) => {
+        const patch = drafts.outputEdits[v.id]
+        return patch ? { ...v, ...patch } : v
+      }),
+    ...drafts.pendingOutputAdds,
+  ]
+
   const normalizedName = nameDisplay.trim().replace(/\s+/g, "_")
   const nameValid = /^[A-Za-z0-9_]+$/.test(normalizedName)
   const duplicateName = otherEstimators.some((e) => e.name === normalizedName)
 
   const nameDirty = drafts.nameDraft != null && normalizedName !== estimator.name
   const descDirty = drafts.descDraft != null && drafts.descDraft !== estimator.description
-  const editsDirty = Object.keys(drafts.variableEdits).length > 0
-  const addsDirty = drafts.pendingAdds.length > 0
-  const deletesDirty = drafts.pendingDeletes.size > 0
-  const isDirty = nameDirty || descDirty || editsDirty || addsDirty || deletesDirty
+  const inputEditsDirty = Object.keys(drafts.inputEdits).length > 0
+  const inputAddsDirty = drafts.pendingInputAdds.length > 0
+  const inputDelsDirty = drafts.pendingInputDeletes.size > 0
+  const outputEditsDirty = Object.keys(drafts.outputEdits).length > 0
+  const outputAddsDirty = drafts.pendingOutputAdds.length > 0
+  const outputDelsDirty = drafts.pendingOutputDeletes.size > 0
+  const isDirty =
+    nameDirty ||
+    descDirty ||
+    inputEditsDirty ||
+    inputAddsDirty ||
+    inputDelsDirty ||
+    outputEditsDirty ||
+    outputAddsDirty ||
+    outputDelsDirty
 
   const canSave =
     isDirty && nameValid && !duplicateName && normalizedName.length > 0
 
-  // ─── Save / Cancel ────────────────────────────────────────────────────────
   function handleSave() {
     if (!canSave) return
 
@@ -109,36 +128,67 @@ export function EstimatorDetailsPanel({
       )
     }
 
-    for (const v of drafts.pendingAdds) {
-      addVariable.mutate(
+    // Inputs
+    for (const v of drafts.pendingInputAdds) {
+      addInput.mutate(
         {
           path: { estimator_id: estimator.id },
           body: {
-            name: v.name,
+            key: v.key,
+            description: v.description || null,
+            parameter_type: v.parameter_type,
+          },
+        },
+        { onError: (err) => toast.error(`Add input failed: ${err.message}`) },
+      )
+    }
+    for (const [inputId, patch] of Object.entries(drafts.inputEdits)) {
+      const body: Schemas.UpdateInputRequest = {
+        key: patch.key,
+        description: patch.description ?? null,
+        parameter_type: patch.parameter_type ?? null,
+      }
+      updateInput.mutate(
+        { path: { estimator_id: estimator.id, input_id: inputId }, body },
+        { onError: (err) => toast.error(`Input update failed: ${err.message}`) },
+      )
+    }
+    for (const inputId of drafts.pendingInputDeletes) {
+      removeInput.mutate(
+        { path: { estimator_id: estimator.id, input_id: inputId } },
+        { onError: (err) => toast.error(`Delete input failed: ${err.message}`) },
+      )
+    }
+
+    // Outputs
+    for (const v of drafts.pendingOutputAdds) {
+      addOutput.mutate(
+        {
+          path: { estimator_id: estimator.id },
+          body: {
+            key: v.key,
             expression: v.expression || "0",
             description: v.description || null,
           },
         },
-        { onError: (err) => toast.error(`Add variable failed: ${err.message}`) },
+        { onError: (err) => toast.error(`Add output failed: ${err.message}`) },
       )
     }
-
-    for (const [variableId, patch] of Object.entries(drafts.variableEdits)) {
-      const body: Schemas.UpdateVariableRequest = {
-        name: patch.name,
+    for (const [outputId, patch] of Object.entries(drafts.outputEdits)) {
+      const body: Schemas.UpdateOutputRequest = {
+        key: patch.key,
         expression: patch.expression,
         description: patch.description ?? null,
       }
-      updateVariable.mutate(
-        { path: { variable_id: variableId }, body },
-        { onError: (err) => toast.error(`Variable update failed: ${err.message}`) },
+      updateOutput.mutate(
+        { path: { estimator_id: estimator.id, output_id: outputId }, body },
+        { onError: (err) => toast.error(`Output update failed: ${err.message}`) },
       )
     }
-
-    for (const variableId of drafts.pendingDeletes) {
-      removeVariable.mutate(
-        { path: { variable_id: variableId } },
-        { onError: (err) => toast.error(`Delete variable failed: ${err.message}`) },
+    for (const outputId of drafts.pendingOutputDeletes) {
+      removeOutput.mutate(
+        { path: { estimator_id: estimator.id, output_id: outputId } },
+        { onError: (err) => toast.error(`Delete output failed: ${err.message}`) },
       )
     }
 
@@ -152,51 +202,93 @@ export function EstimatorDetailsPanel({
     setEditingName(false)
   }
 
-  // ─── Variable mutations (staged in store, not fired) ──────────────────────
-  function handleVariablePatch(variableId: string, patch: Partial<Schemas.VariableResponse>) {
-    if (variableId.startsWith(TEMP_PREFIX)) {
-      // Update the pending addition in place
-      const cur = drafts.pendingAdds.find((v) => v.id === variableId)
+  // ─── Input draft staging ──────────────────────────────────────────────────
+  function handleInputPatch(inputId: string, patch: Partial<Schemas.InputResponse>) {
+    if (inputId.startsWith(TEMP_PREFIX)) {
+      const cur = drafts.pendingInputAdds.find((v) => v.id === inputId)
       if (!cur) return
-      drafts.removePending(variableId)
-      drafts.addPending({ ...cur, ...patch })
+      drafts.removePendingInput(inputId)
+      drafts.addPendingInput({ ...cur, ...patch })
       return
     }
-    // Stage an edit; collapse to no-op if it matches server
-    const server = estimator.variables.find((v) => v.id === variableId)
+    const server = estimator.inputs.find((v) => v.id === inputId)
     if (!server) return
-    const merged = { ...(drafts.variableEdits[variableId] ?? {}), ...patch }
+    const merged = { ...(drafts.inputEdits[inputId] ?? {}), ...patch }
     const allSame =
-      (merged.name === undefined || merged.name === server.name) &&
+      (merged.key === undefined || merged.key === server.key) &&
+      (merged.description === undefined || merged.description === server.description) &&
+      (merged.parameter_type === undefined ||
+        JSON.stringify(merged.parameter_type) === JSON.stringify(server.parameter_type))
+    if (allSame) {
+      drafts.dropInputEdit(inputId)
+      return
+    }
+    drafts.patchInput(inputId, patch)
+  }
+
+  function handleAddInput() {
+    const tempId = `${TEMP_PREFIX}${crypto.randomUUID()}`
+    const n = drafts.pendingInputAdds.length + 1
+    drafts.addPendingInput({
+      id: tempId,
+      key: `input_${n}`,
+      description: "",
+      parameter_type: { kind: "number" },
+    })
+  }
+
+  function handleDeleteInput(inputId: string) {
+    if (inputId.startsWith(TEMP_PREFIX)) {
+      drafts.removePendingInput(inputId)
+      return
+    }
+    drafts.markInputDelete(inputId)
+  }
+
+  // ─── Output draft staging ─────────────────────────────────────────────────
+  function handleOutputPatch(outputId: string, patch: Partial<Schemas.OutputResponse>) {
+    if (outputId.startsWith(TEMP_PREFIX)) {
+      const cur = drafts.pendingOutputAdds.find((v) => v.id === outputId)
+      if (!cur) return
+      drafts.removePendingOutput(outputId)
+      drafts.addPendingOutput({ ...cur, ...patch })
+      return
+    }
+    const server = estimator.outputs.find((v) => v.id === outputId)
+    if (!server) return
+    const merged = { ...(drafts.outputEdits[outputId] ?? {}), ...patch }
+    const allSame =
+      (merged.key === undefined || merged.key === server.key) &&
       (merged.expression === undefined || merged.expression === server.expression) &&
       (merged.description === undefined || merged.description === server.description)
     if (allSame) {
-      drafts.dropVariableEdit(variableId)
+      drafts.dropOutputEdit(outputId)
       return
     }
-    drafts.patchVariable(variableId, patch)
+    drafts.patchOutput(outputId, patch)
   }
 
-  function handleAddVariable() {
+  function handleAddOutput() {
     const tempId = `${TEMP_PREFIX}${crypto.randomUUID()}`
-    const n = drafts.pendingAdds.length + 1
-    drafts.addPending({
+    const n = drafts.pendingOutputAdds.length + 1
+    drafts.addPendingOutput({
       id: tempId,
-      name: `new_var_${n}`,
+      key: `output_${n}`,
       expression: "0",
       description: "",
     })
   }
 
-  function handleDeleteVariable(variableId: string) {
-    if (variableId.startsWith(TEMP_PREFIX)) {
-      drafts.removePending(variableId)
+  function handleDeleteOutput(outputId: string) {
+    if (outputId.startsWith(TEMP_PREFIX)) {
+      drafts.removePendingOutput(outputId)
       return
     }
-    drafts.markDelete(variableId)
+    drafts.markOutputDelete(outputId)
   }
 
-  const ownEstimatorVariableNames = effectiveVariables.map((v) => v.name)
+  const ownInputKeys = effectiveInputs.map((i) => i.key)
+  const ownOutputKeys = effectiveOutputs.map((o) => o.key)
 
   return (
     <>
@@ -257,21 +349,22 @@ export function EstimatorDetailsPanel({
           </p>
         )}
 
+        {/* ─── Inputs ─── */}
+        <div className="flex items-center justify-between mt-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Inputs
+          </h3>
+        </div>
         <p className="text-xs text-muted-foreground">
-          Variables are evaluated in dependency order. Reference fields with <code className="font-mono bg-muted px-1 rounded">@field_key</code>.
+          Parameters required to run this estimator. Types: number, boolean, product.
         </p>
 
-        {effectiveVariables.map((v) => (
-          <VariableCard
-            key={v.id}
-            variable={v}
-            ownEstimatorName={estimator.name}
-            ownEstimatorVariables={ownEstimatorVariableNames.filter((n) => n !== v.name)}
-            availableFieldKeys={availableFieldKeys}
-            otherEstimators={otherEstimators}
-            estimatorsIndex={estimatorsIndex}
-            onUpdate={handleVariablePatch}
-            onDelete={handleDeleteVariable}
+        {effectiveInputs.map((i) => (
+          <InputCard
+            key={i.id}
+            input={i}
+            onUpdate={handleInputPatch}
+            onDelete={handleDeleteInput}
           />
         ))}
 
@@ -279,10 +372,45 @@ export function EstimatorDetailsPanel({
           variant="outline"
           size="sm"
           className="w-full border-dashed"
-          onClick={handleAddVariable}
+          onClick={handleAddInput}
         >
           <Plus className="w-3.5 h-3.5 mr-1.5" />
-          Add variable
+          Add input
+        </Button>
+
+        {/* ─── Outputs ─── */}
+        <div className="flex items-center justify-between mt-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Outputs
+          </h3>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Variables produced by the calculation. Reference inputs with <code className="font-mono bg-muted px-1 rounded">@input_key</code>.
+        </p>
+
+        {effectiveOutputs.map((o) => (
+          <OutputCard
+            key={o.id}
+            output={o}
+            ownEstimatorName={estimator.name}
+            ownInputKeys={ownInputKeys}
+            ownOutputKeys={ownOutputKeys.filter((k) => k !== o.key)}
+            availableFieldKeys={availableFieldKeys}
+            otherEstimators={otherEstimators}
+            estimatorsIndex={estimatorsIndex}
+            onUpdate={handleOutputPatch}
+            onDelete={handleDeleteOutput}
+          />
+        ))}
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full border-dashed"
+          onClick={handleAddOutput}
+        >
+          <Plus className="w-3.5 h-3.5 mr-1.5" />
+          Add output
         </Button>
       </div>
 

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/input-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/input-card.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from "react"
+import { Trash2 } from "lucide-react"
+import type { Schemas } from "@/api/api.client"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+const EMERALD = "hsl(158, 64%, 52%)"
+
+type ParamKind = Schemas.EstimatorParameterTypeDto["kind"]
+
+function paramKindOf(pt: Schemas.EstimatorParameterTypeDto): ParamKind {
+  return pt.kind
+}
+
+function paramLabelFilter(pt: Schemas.EstimatorParameterTypeDto): string {
+  return pt.kind === "product" ? pt.label_filter ?? "" : ""
+}
+
+function buildParamType(kind: ParamKind, labelFilter: string): Schemas.EstimatorParameterTypeDto {
+  if (kind === "product") return { kind: "product", label_filter: labelFilter || null }
+  return { kind }
+}
+
+export function InputCard({
+  input,
+  onUpdate,
+  onDelete,
+}: {
+  input: Schemas.InputResponse
+  onUpdate: (inputId: string, patch: Partial<Schemas.InputResponse>) => void
+  onDelete: (inputId: string) => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [keyDraft, setKeyDraft] = useState(input.key)
+  const [descDraft, setDescDraft] = useState(input.description)
+  const [kindDraft, setKindDraft] = useState<ParamKind>(paramKindOf(input.parameter_type))
+  const [labelFilterDraft, setLabelFilterDraft] = useState(paramLabelFilter(input.parameter_type))
+
+  useEffect(() => {
+    setKeyDraft(input.key)
+    setDescDraft(input.description)
+    setKindDraft(paramKindOf(input.parameter_type))
+    setLabelFilterDraft(paramLabelFilter(input.parameter_type))
+  }, [input.id, input.key, input.description, input.parameter_type])
+
+  const commitKey = () => {
+    const trimmed = keyDraft.trim()
+    if (!trimmed || trimmed === input.key) {
+      setKeyDraft(input.key)
+      return
+    }
+    onUpdate(input.id, { key: trimmed })
+  }
+  const commitDesc = () => {
+    if (descDraft === input.description) return
+    onUpdate(input.id, { description: descDraft })
+  }
+  const commitKind = (next: ParamKind) => {
+    setKindDraft(next)
+    onUpdate(input.id, { parameter_type: buildParamType(next, labelFilterDraft) })
+  }
+  const commitLabelFilter = () => {
+    if (kindDraft !== "product") return
+    if (labelFilterDraft === paramLabelFilter(input.parameter_type)) return
+    onUpdate(input.id, { parameter_type: buildParamType("product", labelFilterDraft) })
+  }
+
+  return (
+    <div className="rounded-md border border-border/60 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-3 py-2 bg-muted/30">
+        <button className="flex-1 text-left" onClick={() => setExpanded((p) => !p)}>
+          <span className="text-sm font-mono font-semibold" style={{ color: EMERALD }}>
+            {input.key}
+          </span>
+          <span className="text-xs text-muted-foreground ml-2">
+            : {input.parameter_type.kind}
+            {input.parameter_type.kind === "product" && input.parameter_type.label_filter
+              ? ` (${input.parameter_type.label_filter})`
+              : ""}
+          </span>
+        </button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive hover:text-destructive shrink-0">
+              <Trash2 className="w-3 h-3" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete input?</AlertDialogTitle>
+              <AlertDialogDescription>
+                "{input.key}" will be permanently deleted.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={() => onDelete(input.id)}
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+
+      {expanded && (
+        <div className="px-3 py-2.5 space-y-2.5 border-t border-border/40">
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs">Key</Label>
+            <Input
+              className="h-7 text-sm font-mono"
+              value={keyDraft}
+              onChange={(e) => setKeyDraft(e.target.value)}
+              onBlur={commitKey}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") (e.target as HTMLInputElement).blur()
+                if (e.key === "Escape") {
+                  setKeyDraft(input.key)
+                  ;(e.target as HTMLInputElement).blur()
+                }
+              }}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs">Type</Label>
+            <Select value={kindDraft} onValueChange={(v) => commitKind(v as ParamKind)}>
+              <SelectTrigger className="h-7 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="number">Number</SelectItem>
+                <SelectItem value="boolean">Boolean</SelectItem>
+                <SelectItem value="product">Product</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {kindDraft === "product" && (
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">Label filter (optional)</Label>
+              <Input
+                className="h-7 text-sm font-mono"
+                placeholder="e.g. socket, lamp"
+                value={labelFilterDraft}
+                onChange={(e) => setLabelFilterDraft(e.target.value)}
+                onBlur={commitLabelFilter}
+              />
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs">Description</Label>
+            <Input
+              className="h-7 text-sm"
+              placeholder="Optional"
+              value={descDraft}
+              onChange={(e) => setDescDraft(e.target.value)}
+              onBlur={commitDesc}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
@@ -36,48 +36,47 @@ type Suggestion = {
   estimatorId?: string
 }
 
-export function VariableCard({
-  variable,
+export function OutputCard({
+  output,
   ownEstimatorName,
-  ownEstimatorVariables,
+  ownInputKeys,
+  ownOutputKeys,
   availableFieldKeys,
   otherEstimators,
   estimatorsIndex,
   onUpdate,
   onDelete,
 }: {
-  variable: Schemas.VariableResponse
+  output: Schemas.OutputResponse
   ownEstimatorName: string
-  ownEstimatorVariables: string[]
+  ownInputKeys: string[]
+  ownOutputKeys: string[]
   availableFieldKeys: string[]
-  otherEstimators: Array<{ id: string; name: string; variables: string[] }>
+  otherEstimators: Array<{ id: string; name: string; outputs: string[] }>
   estimatorsIndex: EstimatorIndex
-  onUpdate: (variableId: string, patch: Partial<Schemas.VariableResponse>) => void
-  onDelete: (variableId: string) => void
+  onUpdate: (outputId: string, patch: Partial<Schemas.OutputResponse>) => void
+  onDelete: (outputId: string) => void
 }) {
-  const [expanded, setExpanded] = useState(!variable.expression)
+  const [expanded, setExpanded] = useState(!output.expression)
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [suggestionFilter, setSuggestionFilter] = useState("")
   const exprRef = useRef<HTMLTextAreaElement>(null)
 
-  const displayExpression = idsToNames(variable.expression, estimatorsIndex)
+  const displayExpression = idsToNames(output.expression, estimatorsIndex)
 
-  const [nameDraft, setNameDraft] = useState(variable.name)
+  const [keyDraft, setKeyDraft] = useState(output.key)
   const [exprDraft, setExprDraft] = useState(displayExpression)
-  const [descDraft, setDescDraft] = useState(variable.description)
-  // Remember which estimator id was chosen for each `name.var` via autocomplete,
-  // so free-form editing doesn't silently reroute to the first same-named estimator.
+  const [descDraft, setDescDraft] = useState(output.description)
   const pickedIdsRef = useRef<Map<string, string>>(new Map())
 
   useEffect(() => {
-    setNameDraft(variable.name)
-    setExprDraft(idsToNames(variable.expression, estimatorsIndex))
-    setDescDraft(variable.description)
+    setKeyDraft(output.key)
+    setExprDraft(idsToNames(output.expression, estimatorsIndex))
+    setDescDraft(output.description)
     pickedIdsRef.current = new Map()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [variable.id, variable.name, variable.expression, variable.description])
+  }, [output.id, output.key, output.expression, output.description])
 
-  // Dropdown portal positioning — escapes all parent overflow clips
   const [dropdownPos, setDropdownPos] = useState<{
     top: number
     left: number
@@ -122,28 +121,30 @@ export function VariableCard({
 
   const filterLower = suggestionFilter.toLowerCase()
   const suggestions: Suggestion[] = [
-    // Fields
     ...availableFieldKeys
       .filter((k) => k.toLowerCase().includes(filterLower))
       .map((k) => ({ label: `@${k}`, insert: `@${k}`, group: "Fields" })),
-    // Functions
     ...AGG_FUNCTIONS
       .filter((fn) => fn.toLowerCase().includes(filterLower))
       .map((fn) => ({ label: `${fn}(@...)`, insert: `${fn}(@)`, group: "Functions" })),
-    // Variables of the current estimator (bare references)
-    ...ownEstimatorVariables
-      .filter((v) => v.toLowerCase().includes(filterLower))
-      .map((v) => ({
-        label: `@${v}`,
-        insert: `@${v}`,
+    ...ownInputKeys
+      .filter((k) => k.toLowerCase().includes(filterLower))
+      .map((k) => ({
+        label: `@${k}`,
+        insert: `@${k}`,
+        group: "Inputs",
+      })),
+    ...ownOutputKeys
+      .filter((k) => k.toLowerCase().includes(filterLower))
+      .map((k) => ({
+        label: `@${k}`,
+        insert: `@${k}`,
         group: ownEstimatorName.replace(/_/g, " "),
         isEstimator: true,
       })),
-    // Variables of other estimators (cross-references).
-    // Group key uses estimator id so duplicates stay separate.
     ...otherEstimators.flatMap((est) => {
       const displayName = est.name.replace(/_/g, " ")
-      return est.variables
+      return est.outputs
         .filter((v) =>
           v.toLowerCase().includes(filterLower) ||
           `${est.name}.${v}`.toLowerCase().includes(filterLower) ||
@@ -183,10 +184,10 @@ export function VariableCard({
     const stored = namesToIdsPreservingIds(
       newVal,
       estimatorsIndex,
-      variable.expression,
+      output.expression,
       pickedIdsRef.current,
     )
-    onUpdate(variable.id, { expression: stored })
+    onUpdate(output.id, { expression: stored })
 
     requestAnimationFrame(() => {
       el.focus()
@@ -211,47 +212,43 @@ export function VariableCard({
     }
   }
 
-  const commitName = () => {
-    const trimmed = nameDraft.trim()
-    if (!trimmed || trimmed === variable.name) {
-      setNameDraft(variable.name)
+  const commitKey = () => {
+    const trimmed = keyDraft.trim()
+    if (!trimmed || trimmed === output.key) {
+      setKeyDraft(output.key)
       return
     }
-    onUpdate(variable.id, { name: trimmed })
+    onUpdate(output.id, { key: trimmed })
   }
   const commitExpr = () => {
     if (!exprDraft.trim()) {
-      setExprDraft(idsToNames(variable.expression, estimatorsIndex))
+      setExprDraft(idsToNames(output.expression, estimatorsIndex))
       return
     }
     const stored = namesToIdsPreservingIds(
       exprDraft,
       estimatorsIndex,
-      variable.expression,
+      output.expression,
       pickedIdsRef.current,
     )
-    if (stored === variable.expression) return
-    onUpdate(variable.id, { expression: stored })
+    if (stored === output.expression) return
+    onUpdate(output.id, { expression: stored })
   }
   const commitDesc = () => {
-    if (descDraft === variable.description) return
-    onUpdate(variable.id, { description: descDraft })
+    if (descDraft === output.description) return
+    onUpdate(output.id, { description: descDraft })
   }
 
   return (
     <div className="rounded-md border border-border/60 overflow-hidden">
-      {/* Header row */}
       <div className="flex items-center gap-1.5 px-3 py-2 bg-muted/30">
-        <button
-          className="flex-1 text-left"
-          onClick={() => setExpanded((p) => !p)}
-        >
+        <button className="flex-1 text-left" onClick={() => setExpanded((p) => !p)}>
           <span className="text-sm font-mono font-semibold" style={{ color: ROSE }}>
-            {variable.name}
+            {output.key}
           </span>
-          {!expanded && variable.expression && (
+          {!expanded && output.expression && (
             <span className="text-xs text-muted-foreground ml-2 font-mono">
-              = {variable.expression.length > 20 ? variable.expression.slice(0, 20) + "..." : variable.expression}
+              = {output.expression.length > 20 ? output.expression.slice(0, 20) + "..." : output.expression}
             </span>
           )}
         </button>
@@ -263,16 +260,16 @@ export function VariableCard({
           </AlertDialogTrigger>
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>Delete variable?</AlertDialogTitle>
+              <AlertDialogTitle>Delete output?</AlertDialogTitle>
               <AlertDialogDescription>
-                "{variable.name}" will be permanently deleted.
+                "{output.key}" will be permanently deleted.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                onClick={() => onDelete(variable.id)}
+                onClick={() => onDelete(output.id)}
               >
                 Delete
               </AlertDialogAction>
@@ -281,28 +278,25 @@ export function VariableCard({
         </AlertDialog>
       </div>
 
-      {/* Expanded editor */}
       {expanded && (
         <div className="px-3 py-2.5 space-y-2.5 border-t border-border/40">
-          {/* Name */}
           <div className="flex flex-col gap-1">
-            <Label className="text-xs">Name</Label>
+            <Label className="text-xs">Key</Label>
             <Input
               className="h-7 text-sm font-mono"
-              value={nameDraft}
-              onChange={(e) => setNameDraft(e.target.value)}
-              onBlur={commitName}
+              value={keyDraft}
+              onChange={(e) => setKeyDraft(e.target.value)}
+              onBlur={commitKey}
               onKeyDown={(e) => {
                 if (e.key === "Enter") (e.target as HTMLInputElement).blur()
                 if (e.key === "Escape") {
-                  setNameDraft(variable.name)
+                  setKeyDraft(output.key)
                   ;(e.target as HTMLInputElement).blur()
                 }
               }}
             />
           </div>
 
-          {/* Expression */}
           <div className="flex flex-col gap-1 relative">
             <Label className="text-xs">Expression</Label>
             <Textarea
@@ -367,7 +361,6 @@ export function VariableCard({
               )}
           </div>
 
-          {/* Description */}
           <div className="flex flex-col gap-1">
             <Label className="text-xs">Description</Label>
             <Input

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/estimator-node.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/estimator-node.tsx
@@ -6,35 +6,50 @@ import { NodeDescriptionTooltip } from "./node-description-tooltip"
 export type EstimatorNodeData = {
   name: string
   description: string
-  variables: Schemas.VariableResponse[]
+  inputs: Schemas.InputResponse[]
+  outputs: Schemas.OutputResponse[]
   color: string
   onDelete: () => void
 }
 
-// Layout constants used both for handle positioning and node sizing.
-const HEADER_H = 38 // px — header (icon + title + border)
-const BODY_PY = 8 // px — vertical padding inside variables list
-const ROW_H = 20 // px — each variable row
-const ROW_GAP = 4 // px — space-y-1 gap between rows
+const HEADER_H = 38
+const BODY_PY = 8
+const ROW_H = 20
+const ROW_GAP = 4
+const SECTION_GAP = 12
+const SECTION_HEADER_H = 14
 
-/** Y position (in px from node top) of the center of variable at index `i`. */
-function variableHandleY(i: number): number {
-  return HEADER_H + BODY_PY + i * (ROW_H + ROW_GAP) + ROW_H / 2
+function inputHandleY(i: number): number {
+  return HEADER_H + BODY_PY + SECTION_HEADER_H + i * (ROW_H + ROW_GAP) + ROW_H / 2
+}
+
+function outputHandleY(inputCount: number, i: number): number {
+  const inputsBlock = inputCount * (ROW_H + ROW_GAP) - (inputCount > 0 ? ROW_GAP : 0)
+  const base = HEADER_H + BODY_PY + SECTION_HEADER_H + inputsBlock + SECTION_GAP + SECTION_HEADER_H
+  return base + i * (ROW_H + ROW_GAP) + ROW_H / 2
+}
+
+function paramTypeLabel(pt: Schemas.EstimatorParameterTypeDto): string {
+  if (pt.kind === "product") {
+    return pt.label_filter ? `product<${pt.label_filter}>` : "product"
+  }
+  return pt.kind
 }
 
 export function EstimatorNode({ data, selected }: NodeProps<Node<EstimatorNodeData>>) {
   const c = data.color
-  const ringColor = `${c.replace(")", " / 0.2)")}` // e.g. hsl(330, 80%, 60% / 0.2)
+  const ringColor = `${c.replace(")", " / 0.2)")}`
+  const inputColor = "hsl(158, 64%, 52%)"
 
   const nodeInner = (
     <div
-      className="group relative min-w-[200px] max-w-[240px] rounded-md border bg-card text-card-foreground shadow-sm transition-shadow cursor-pointer"
+      className="group relative min-w-[220px] max-w-[260px] rounded-md border bg-card text-card-foreground shadow-sm transition-shadow cursor-pointer"
       style={{
         borderColor: selected ? c : undefined,
         boxShadow: selected ? `0 0 0 3px ${ringColor}` : undefined,
       }}
     >
-      {/* Fallback handles at the header level (used when no variables exist) */}
+      {/* Fallback handles at header when no inputs/outputs */}
       <Handle
         type="target"
         position={Position.Left}
@@ -50,22 +65,34 @@ export function EstimatorNode({ data, selected }: NodeProps<Node<EstimatorNodeDa
         style={{ backgroundColor: c, top: HEADER_H / 2 }}
       />
 
-      {/* Per-variable handles: one pair (target left + source right) per variable */}
-      {data.variables.map((v, i) => {
-        const y = variableHandleY(i)
+      {/* Per-input target handles (left) */}
+      {data.inputs.map((i, idx) => (
+        <Handle
+          key={`target-input-${i.id}`}
+          type="target"
+          position={Position.Left}
+          id={`target-input-${i.id}`}
+          className="!border-2 !border-background !w-2 !h-2"
+          style={{ backgroundColor: inputColor, top: inputHandleY(idx) }}
+        />
+      ))}
+
+      {/* Per-output source handles (right) + a target on the output for chaining */}
+      {data.outputs.map((o, idx) => {
+        const y = outputHandleY(data.inputs.length, idx)
         return (
-          <div key={`handles-${v.id}`}>
+          <div key={`handles-${o.id}`}>
             <Handle
               type="target"
               position={Position.Left}
-              id={`target-${v.id}`}
+              id={`target-${o.id}`}
               className="!border-2 !border-background !w-2 !h-2"
               style={{ backgroundColor: c, top: y }}
             />
             <Handle
               type="source"
               position={Position.Right}
-              id={`source-${v.id}`}
+              id={`source-${o.id}`}
               className="!border-2 !border-background !w-2 !h-2"
               style={{ backgroundColor: c, top: y }}
             />
@@ -102,25 +129,72 @@ export function EstimatorNode({ data, selected }: NodeProps<Node<EstimatorNodeDa
         </p>
       </div>
 
-      {/* Variables list — each row uses the same height as our handle offsets */}
+      {/* Body: Inputs section (left-anchored) + Outputs section (right-anchored) */}
       <div className="px-3" style={{ paddingTop: BODY_PY, paddingBottom: BODY_PY }}>
-        {data.variables.length === 0 ? (
-          <p className="text-xs text-muted-foreground/50 italic">No variables</p>
+        {/* Inputs */}
+        <div
+          className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+          style={{ height: SECTION_HEADER_H, lineHeight: `${SECTION_HEADER_H}px` }}
+        >
+          Inputs
+        </div>
+        {data.inputs.length === 0 ? (
+          <div
+            className="text-xs text-muted-foreground/50 italic"
+            style={{ height: ROW_H, lineHeight: `${ROW_H}px` }}
+          >
+            None
+          </div>
         ) : (
-          data.variables.map((v, i) => (
+          data.inputs.map((i, idx) => (
             <div
-              key={v.id}
+              key={i.id}
               className="flex items-center gap-1.5"
-              style={{ height: ROW_H, marginTop: i === 0 ? 0 : ROW_GAP }}
+              style={{ height: ROW_H, marginTop: idx === 0 ? 0 : ROW_GAP }}
             >
               <span
                 className="text-xs font-mono font-medium shrink-0"
-                style={{ color: c }}
+                style={{ color: inputColor }}
               >
-                {v.name.replace(/_/g, " ")}
+                {i.key}
               </span>
-              <span className="text-xs text-muted-foreground truncate">
-                = {v.expression}
+              <span className="text-[10px] text-muted-foreground truncate">
+                : {paramTypeLabel(i.parameter_type)}
+              </span>
+            </div>
+          ))
+        )}
+
+        {/* Outputs */}
+        <div
+          className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground text-right"
+          style={{
+            height: SECTION_HEADER_H,
+            lineHeight: `${SECTION_HEADER_H}px`,
+            marginTop: SECTION_GAP,
+          }}
+        >
+          Outputs
+        </div>
+        {data.outputs.length === 0 ? (
+          <div
+            className="text-xs text-muted-foreground/50 italic text-right"
+            style={{ height: ROW_H, lineHeight: `${ROW_H}px` }}
+          >
+            None
+          </div>
+        ) : (
+          data.outputs.map((o, idx) => (
+            <div
+              key={o.id}
+              className="flex items-center justify-end gap-1.5"
+              style={{ height: ROW_H, marginTop: idx === 0 ? 0 : ROW_GAP }}
+            >
+              <span className="text-[10px] text-muted-foreground truncate">
+                = {o.expression}
+              </span>
+              <span className="text-xs font-mono font-medium shrink-0" style={{ color: c }}>
+                {o.key}
               </span>
             </div>
           ))


### PR DESCRIPTION
This pull request introduces a major refactor of the estimator API, replacing the old "variables" concept with explicit "inputs" and "outputs" for estimators. It updates both backend DTOs and the frontend API client, and provides new React hooks for managing estimator inputs and outputs. The changes also add support for flow bindings and submissions, and remove all references to the deprecated "variables" endpoints and types.

The most important changes are:

**Estimator Inputs/Outputs Refactor:**
- Replaces the "variables" model with explicit "inputs" and "outputs" for estimators, updating all related DTOs, API endpoints, and client types (`EstimatorParameterTypeDto`, `InputResponse`, `OutputResponse`, etc.) [[1]](diffhunk://#diff-3935793b00683f5200b45c745a3e274334dc9cc72897ae48f7f536018dc2f50eL46) [[2]](diffhunk://#diff-3935793b00683f5200b45c745a3e274334dc9cc72897ae48f7f536018dc2f50eL103) [[3]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L3-R55) [[4]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R98-R106) [[5]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L71-R158) [[6]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L86) [[7]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R189-R195) [[8]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R204-R213) [[9]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L125-L129) [[10]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L188-R340) [[11]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R581-R617) [[12]](diffhunk://#diff-267e8cc8091b0f85b5a32d95806cd2e0f5e4a7de67eb2f41e97324c0bfe53f3aL7-R8)

**API Endpoint Changes:**
- Adds new endpoints for creating, updating, and deleting estimator inputs and outputs (`/api/v1/estimators/{estimator_id}/inputs`, `/outputs`), and removes all variable endpoints. [[1]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L188-R340) [[2]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R581-R617)
- Introduces endpoints for managing bindings and submissions on flows, including listing, creating, updating, and deleting bindings and submissions. [[1]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R460-R499) [[2]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L359-R569) [[3]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R581-R617)

**Frontend API Client Updates:**
- Updates the TypeScript API client types and endpoint definitions to match the backend changes, including new request/response types for inputs, outputs, bindings, and submissions. [[1]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L3-R55) [[2]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R98-R106) [[3]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L71-R158) [[4]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L86) [[5]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R189-R195) [[6]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R204-R213) [[7]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L125-L129) [[8]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L188-R340) [[9]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R460-R499) [[10]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6L359-R569) [[11]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R581-R617)

**React Query Hooks Refactor:**
- Removes hooks for variables and adds new hooks for managing estimator inputs and outputs (`useAddInput`, `useUpdateInput`, `useRemoveInput`, `useAddOutput`, `useUpdateOutput`, `useRemoveOutput`), with a shared cache invalidator. [[1]](diffhunk://#diff-1b0a4bda51c0ee7ba90bfcdf59e4f4b4ef4c718413d072b92dd000d69896f405L68-R71) [[2]](diffhunk://#diff-1b0a4bda51c0ee7ba90bfcdf59e4f4b4ef4c718413d072b92dd000d69896f405L86-R133)

**Documentation and Code Comments:**
- Updates comments and documentation throughout the codebase to reflect the new inputs/outputs model and remove references to variables.

These changes modernize the estimator API, clarify the data model, and provide a more robust and maintainable foundation for estimator configuration and flow execution.