### PR TITLE
feat(front): flow canvas estimator binding configuration UI map/reduce argument mapping

### DIFF
--- a/apps/ferrisquote-webapp/src/api/api.client.ts
+++ b/apps/ferrisquote-webapp/src/api/api.client.ts
@@ -165,6 +165,7 @@ export namespace Schemas {
     title: string;
   };
   export type EstimatorListResponse = { estimators: Array<EstimatorResponse> };
+  export type EvaluateBindingsRequest = { answers: Record<string, Array<StepIterationDto>>; user_id: string };
   export type EvaluateFlowResponse = {
     flat_results: Record<string, number>;
     results: Record<string, Record<string, number>>;
@@ -177,7 +178,12 @@ export namespace Schemas {
     iteration_counts: Record<string, number>;
     iteration_values: Record<string, Array<number>>;
   };
+  export type FlowEvaluationResponse = {
+    bindings: Record<string, Record<string, number>>;
+    flat: Record<string, number>;
+  };
   export type FlowListResponse = { flows: Array<FlowSummaryResponse> };
+  export type FlowPreviewResponse = { evaluation: FlowEvaluationResponse; submission: SubmissionResponse };
   export type FlowResponse = { description: string; id: string; name: string; steps: Array<StepResponse> };
   export type MessageResponse = { message: string };
   export type MoveFieldRequest = Partial<{
@@ -528,6 +534,26 @@ export namespace Endpoints {
     };
     responses: { 200: Schemas.EvaluateFlowResponse; 400: unknown; 404: unknown };
   };
+  export type post_Evaluate_bindings = {
+    method: "POST";
+    path: "/api/v1/flows/{flow_id}/evaluate-bindings";
+    requestFormat: "json";
+    parameters: {
+      path: { flow_id: string };
+
+      body: Schemas.EvaluateBindingsRequest;
+    };
+    responses: { 200: Schemas.FlowEvaluationResponse; 400: unknown; 404: unknown };
+  };
+  export type post_Preview_flow = {
+    method: "POST";
+    path: "/api/v1/flows/{flow_id}/evaluate-bindings-preview";
+    requestFormat: "json";
+    parameters: {
+      path: { flow_id: string };
+    };
+    responses: { 200: Schemas.FlowPreviewResponse; 400: unknown; 404: unknown };
+  };
   export type post_Add_step = {
     method: "POST";
     path: "/api/v1/flows/{flow_id}/steps";
@@ -613,6 +639,8 @@ export type EndpointByMethod = {
     "/api/v1/flows/{flow_id}/bindings": Endpoints.post_Add_binding;
     "/api/v1/flows/{flow_id}/estimators": Endpoints.post_Create_estimator;
     "/api/v1/flows/{flow_id}/evaluate-all": Endpoints.post_Evaluate_flow;
+    "/api/v1/flows/{flow_id}/evaluate-bindings": Endpoints.post_Evaluate_bindings;
+    "/api/v1/flows/{flow_id}/evaluate-bindings-preview": Endpoints.post_Preview_flow;
     "/api/v1/flows/{flow_id}/steps": Endpoints.post_Add_step;
     "/api/v1/flows/{flow_id}/submissions": Endpoints.post_Submit_answers;
   };

--- a/apps/ferrisquote-webapp/src/api/bindings.api.ts
+++ b/apps/ferrisquote-webapp/src/api/bindings.api.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import type { Schemas } from "@/api/api.client"
+
+// ─── Bindings ─────────────────────────────────────────────────────────────────
+
+export const useBindings = (flowId: string) =>
+  useQuery({
+    ...window.tanstackApi.get("/api/v1/flows/{flow_id}/bindings", {
+      path: { flow_id: flowId },
+    }).queryOptions,
+    enabled: !!flowId,
+  })
+
+function invalidateFlow(
+  qc: ReturnType<typeof useQueryClient>,
+  flowId: string,
+) {
+  return qc.invalidateQueries({
+    queryKey: window.tanstackApi.get("/api/v1/flows/{flow_id}/bindings", {
+      path: { flow_id: flowId },
+    }).queryKey,
+  })
+}
+
+export const useCreateBinding = (flowId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation("post", "/api/v1/flows/{flow_id}/bindings").mutationOptions,
+    onSuccess: () => invalidateFlow(qc, flowId),
+  })
+}
+
+export const useUpdateBinding = (flowId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation("put", "/api/v1/flows/{flow_id}/bindings/{binding_id}").mutationOptions,
+    onSuccess: () => invalidateFlow(qc, flowId),
+  })
+}
+
+export const useDeleteBinding = (flowId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation("delete", "/api/v1/flows/{flow_id}/bindings/{binding_id}").mutationOptions,
+    onSuccess: () => invalidateFlow(qc, flowId),
+  })
+}
+
+// ─── Evaluation ───────────────────────────────────────────────────────────────
+
+export const useEvaluateBindings = () =>
+  useMutation({
+    ...window.tanstackApi.mutation("post", "/api/v1/flows/{flow_id}/evaluate-bindings").mutationOptions,
+  })
+
+export const usePreviewFlow = () =>
+  useMutation({
+    ...window.tanstackApi.mutation("post", "/api/v1/flows/{flow_id}/evaluate-bindings-preview").mutationOptions,
+  })
+
+export type { Schemas }

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
@@ -28,6 +28,7 @@ import {
   useGetFlow,
 } from "@/api/flows.api"
 import { useCreateEstimator, useDeleteEstimator, useEstimators } from "@/api/estimators.api"
+import { useBindings, useCreateBinding } from "@/api/bindings.api"
 import {
   overlayEstimators,
   useEstimatorDraftStore,
@@ -469,8 +470,10 @@ function FlowCanvasImpl({ flowId, panelState, setPanelState }: Props) {
 
   const { data: flowData } = useGetFlow(flowId)
   const { data: estimatorsData } = useEstimators(flowId)
+  const { data: bindingsData } = useBindings(flowId)
   const flow = flowData?.data ?? null
   const rawEstimators = estimatorsData?.data?.estimators ?? []
+  const bindings = bindingsData?.data?.bindings ?? []
 
   // Overlay sidenav drafts so the graph reflects unsaved edits live
   const drafts = useEstimatorDraftStore()
@@ -487,6 +490,7 @@ function FlowCanvasImpl({ flowId, panelState, setPanelState }: Props) {
   const { mutate: createEstimator } = useCreateEstimator(flowId)
   const { mutate: deleteEstimator } = useDeleteEstimator(flowId)
   const { mutate: reorderStep } = useReorderStep(flowId)
+  const { mutate: createBinding } = useCreateBinding(flowId)
 
   // ─── Canvas hooks ─────────────────────────────────────────────────────────
   const { linkingField, setLinkingField } = useLinkingMode(flow, fitView)
@@ -545,6 +549,20 @@ function FlowCanvasImpl({ flowId, panelState, setPanelState }: Props) {
 
     if (node.type === "estimatorNode") {
       const estimatorId = node.id.replace("estimator-", "")
+      // Open the unified estimator panel. Silently ensure a binding exists —
+      // the panel surfaces wiring + reduce sections only once we have one.
+      const existing = bindings.find((b) => b.estimator_id === estimatorId)
+      if (!existing) {
+        createBinding({
+          path: { flow_id: flowId },
+          body: {
+            estimator_id: estimatorId,
+            inputs_mapping: {},
+            map_over_step: null,
+            outputs_reduce_strategy: {},
+          },
+        })
+      }
       setPanelState({ mode: "estimator-details", estimatorId })
       return
     }

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-edit-panel.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-edit-panel.tsx
@@ -9,6 +9,7 @@ import {
   useUpdateStep,
 } from "@/api/flows.api"
 import { useEstimators } from "@/api/estimators.api"
+import { useBindings } from "@/api/bindings.api"
 import { AddFieldForm } from "@/pages/flows/ui/edit-panel/add-field-form"
 import { AddStepForm } from "@/pages/flows/ui/edit-panel/add-step-form"
 import { EditFieldForm } from "@/pages/flows/ui/edit-panel/edit-field-form"
@@ -36,8 +37,10 @@ function FlowEditPanelImpl({ flowId, state, onClose, setPanelState }: Props) {
   // Queries
   const { data: flowData } = useGetFlow(flowId)
   const { data: estimatorsData } = useEstimators(flowId)
+  const { data: bindingsData } = useBindings(flowId)
   const flow = flowData?.data ?? null
   const estimators = estimatorsData?.data?.estimators ?? []
+  const bindings = bindingsData?.data?.bindings ?? []
 
   // Sidenav-side mutations (forms submit → mutation here, parent stays clean)
   const { mutate: addStep } = useAddStep(flowId)
@@ -59,6 +62,16 @@ function FlowEditPanelImpl({ flowId, state, onClose, setPanelState }: Props) {
     state?.mode === "estimator-details"
       ? estimators.find((e) => e.id === state.estimatorId) ?? null
       : null
+  // The unified panel also edits the binding when one exists for this
+  // estimator — one binding per estimator by convention.
+  const activeBinding =
+    estimator != null
+      ? bindings.find((b) => b.estimator_id === estimator.id) ?? null
+      : null
+  const otherBindings =
+    activeBinding != null
+      ? bindings.filter((b) => b.id !== activeBinding.id)
+      : bindings
 
   // Autocomplete data: only numeric fields make sense as operands in an
   // estimator expression (text/date/select/boolean are not directly usable
@@ -169,11 +182,14 @@ function FlowEditPanelImpl({ flowId, state, onClose, setPanelState }: Props) {
             onSubmit={handleEditField}
           />
         )}
-        {state?.mode === "estimator-details" && estimator && (
+        {state?.mode === "estimator-details" && estimator && flow && (
           <EstimatorDetailsPanel
             key={estimator.id}
             estimator={estimator}
             flowId={flowId}
+            flow={flow}
+            binding={activeBinding}
+            otherBindings={otherBindings}
             availableFieldKeys={availableFieldKeys}
             otherEstimators={otherEstimators}
             estimatorsIndex={estimatorsIndex}

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Loader2, Plus, X } from "lucide-react"
 import { toast } from "sonner"
 import type { Schemas } from "@/api/api.client"
@@ -11,6 +11,7 @@ import {
   useUpdateInput,
   useUpdateOutput,
 } from "@/api/estimators.api"
+import { useUpdateBinding } from "@/api/bindings.api"
 import { type EstimatorIndex } from "@/pages/flows/lib/expression-refs"
 import {
   TEMP_PREFIX,
@@ -19,15 +20,31 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { InputCard } from "./input-card"
 import { OutputCard } from "./output-card"
 
 const ROSE = "hsl(330, 80%, 60%)"
+const EMERALD = "hsl(158, 64%, 52%)"
+
+// OpenAPI generator widens these to `Record<string, unknown>` — we restore the
+// real wire shape locally instead of leaking `unknown` through the UI.
+type InputsMap = Record<string, Schemas.InputBindingValueDto>
+type ReduceMap = Record<string, Schemas.AggregationStrategyDto>
 
 export function EstimatorDetailsPanel({
   estimator,
   flowId,
+  flow,
+  binding,
+  otherBindings,
   availableFieldKeys,
   otherEstimators,
   estimatorsIndex,
@@ -35,6 +52,10 @@ export function EstimatorDetailsPanel({
 }: {
   estimator: Schemas.EstimatorResponse
   flowId: string
+  flow: Schemas.FlowResponse
+  /** Optional — unified panel also edits the binding's wiring when one exists. */
+  binding: Schemas.BindingResponse | null
+  otherBindings: Schemas.BindingResponse[]
   availableFieldKeys: string[]
   otherEstimators: Array<{ id: string; name: string; outputs: string[] }>
   estimatorsIndex: EstimatorIndex
@@ -65,6 +86,7 @@ export function EstimatorDetailsPanel({
   const addOutput = useAddOutput(flowId, estimator.id)
   const updateOutput = useUpdateOutput(flowId, estimator.id)
   const removeOutput = useRemoveOutput(flowId, estimator.id)
+  const updateBinding = useUpdateBinding(flowId)
 
   const nameDisplay =
     drafts.nameDraft != null ? drafts.nameDraft : estimator.name.replace(/_/g, " ")
@@ -90,6 +112,42 @@ export function EstimatorDetailsPanel({
     ...drafts.pendingOutputAdds,
   ]
 
+  // ─── Binding wiring local state ──────────────────────────────────────────
+  const serverInputsMap = (binding?.inputs_mapping ?? {}) as InputsMap
+  const serverReduceMap = (binding?.outputs_reduce_strategy ?? {}) as ReduceMap
+  const serverMapOver = binding?.map_over_step ?? null
+
+  const [mapOverStep, setMapOverStep] = useState<string | null>(serverMapOver)
+  const [inputsMapping, setInputsMapping] = useState<InputsMap>(serverInputsMap)
+  const [reduceMap, setReduceMap] = useState<ReduceMap>(serverReduceMap)
+
+  useEffect(() => {
+    setMapOverStep(serverMapOver)
+    setInputsMapping(serverInputsMap)
+    setReduceMap(serverReduceMap)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [binding?.id])
+
+  const allFields = useMemo(
+    () =>
+      flow.steps.flatMap((s) =>
+        s.fields.map((f) => ({
+          id: f.id,
+          key: f.key,
+          label: f.label,
+          stepId: s.id,
+          numeric: f.config.type === "number",
+        })),
+      ),
+    [flow.steps],
+  )
+
+  const repeatableSteps = useMemo(
+    () => flow.steps.filter((s) => s.is_repeatable),
+    [flow.steps],
+  )
+
+  // ─── Validation + dirty detection ────────────────────────────────────────
   const normalizedName = nameDisplay.trim().replace(/\s+/g, "_")
   const nameValid = /^[A-Za-z0-9_]+$/.test(normalizedName)
   const duplicateName = otherEstimators.some((e) => e.name === normalizedName)
@@ -102,6 +160,13 @@ export function EstimatorDetailsPanel({
   const outputEditsDirty = Object.keys(drafts.outputEdits).length > 0
   const outputAddsDirty = drafts.pendingOutputAdds.length > 0
   const outputDelsDirty = drafts.pendingOutputDeletes.size > 0
+
+  const bindingDirty =
+    binding != null &&
+    (mapOverStep !== serverMapOver ||
+      JSON.stringify(inputsMapping) !== JSON.stringify(serverInputsMap) ||
+      JSON.stringify(reduceMap) !== JSON.stringify(serverReduceMap))
+
   const isDirty =
     nameDirty ||
     descDirty ||
@@ -110,11 +175,13 @@ export function EstimatorDetailsPanel({
     inputDelsDirty ||
     outputEditsDirty ||
     outputAddsDirty ||
-    outputDelsDirty
+    outputDelsDirty ||
+    bindingDirty
 
   const canSave =
     isDirty && nameValid && !duplicateName && normalizedName.length > 0
 
+  // ─── Save ────────────────────────────────────────────────────────────────
   function handleSave() {
     if (!canSave) return
 
@@ -128,7 +195,6 @@ export function EstimatorDetailsPanel({
       )
     }
 
-    // Inputs
     for (const v of drafts.pendingInputAdds) {
       addInput.mutate(
         {
@@ -160,7 +226,6 @@ export function EstimatorDetailsPanel({
       )
     }
 
-    // Outputs
     for (const v of drafts.pendingOutputAdds) {
       addOutput.mutate(
         {
@@ -192,6 +257,20 @@ export function EstimatorDetailsPanel({
       )
     }
 
+    if (bindingDirty && binding) {
+      updateBinding.mutate(
+        {
+          path: { flow_id: flowId, binding_id: binding.id },
+          body: {
+            inputs_mapping: inputsMapping,
+            outputs_reduce_strategy: reduceMap,
+            map_over_step: mapOverStep,
+          },
+        },
+        { onError: (err) => toast.error(`Wiring update failed: ${err.message}`) },
+      )
+    }
+
     drafts.clear()
     drafts.setActive(estimator.id)
   }
@@ -200,9 +279,12 @@ export function EstimatorDetailsPanel({
     drafts.clear()
     drafts.setActive(estimator.id)
     setEditingName(false)
+    setMapOverStep(serverMapOver)
+    setInputsMapping(serverInputsMap)
+    setReduceMap(serverReduceMap)
   }
 
-  // ─── Input draft staging ──────────────────────────────────────────────────
+  // ─── Input/Output draft staging (unchanged) ──────────────────────────────
   function handleInputPatch(inputId: string, patch: Partial<Schemas.InputResponse>) {
     if (inputId.startsWith(TEMP_PREFIX)) {
       const cur = drafts.pendingInputAdds.find((v) => v.id === inputId)
@@ -245,7 +327,6 @@ export function EstimatorDetailsPanel({
     drafts.markInputDelete(inputId)
   }
 
-  // ─── Output draft staging ─────────────────────────────────────────────────
   function handleOutputPatch(outputId: string, patch: Partial<Schemas.OutputResponse>) {
     if (outputId.startsWith(TEMP_PREFIX)) {
       const cur = drafts.pendingOutputAdds.find((v) => v.id === outputId)
@@ -290,6 +371,49 @@ export function EstimatorDetailsPanel({
   const ownInputKeys = effectiveInputs.map((i) => i.key)
   const ownOutputKeys = effectiveOutputs.map((o) => o.key)
 
+  // ─── Wiring helpers ──────────────────────────────────────────────────────
+  function currentSelectValue(inputKey: string): string {
+    const v = inputsMapping[inputKey]
+    if (!v) return ""
+    if (v.source === "field") return `field:${v.field_id}`
+    if (v.source === "binding_output") return `binding:${v.binding_id}.${v.output_key}`
+    return ""
+  }
+
+  function handleSourceChange(inputKey: string, raw: string, numericOnly: boolean) {
+    if (raw === "__unset__") {
+      setInputsMapping((prev) => {
+        const next = { ...prev }
+        delete next[inputKey]
+        return next
+      })
+      return
+    }
+    if (raw.startsWith("field:")) {
+      const fid = raw.slice("field:".length)
+      const meta = allFields.find((f) => f.id === fid)
+      if (!meta) return
+      if (numericOnly && !meta.numeric) {
+        toast.error(`Field '${meta.key}' is not numeric`)
+        return
+      }
+      setInputsMapping((prev) => ({ ...prev, [inputKey]: { source: "field", field_id: fid } }))
+    } else if (raw.startsWith("binding:")) {
+      const [bid, okey] = raw.slice("binding:".length).split(".", 2)
+      setInputsMapping((prev) => ({
+        ...prev,
+        [inputKey]: { source: "binding_output", binding_id: bid, output_key: okey },
+      }))
+    }
+  }
+
+  function setReduceStrategy(outputKey: string, strategy: Schemas.AggregationStrategyDto) {
+    setReduceMap((prev) => ({ ...prev, [outputKey]: strategy }))
+  }
+
+  const hasInputs = effectiveInputs.length > 0
+  const showReduce = mapOverStep !== null && effectiveOutputs.length > 0
+
   return (
     <>
       <div className="flex items-center gap-2 px-5 pt-4 pb-2 border-b shrink-0">
@@ -324,7 +448,7 @@ export function EstimatorDetailsPanel({
         )}
       </div>
 
-      <div className="flex flex-col gap-3 px-5 py-4 flex-1 overflow-y-auto pb-4">
+      <div className="flex flex-col gap-3 px-5 py-4 flex-1 min-h-0 overflow-y-auto pb-4">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="estimator-desc" className="text-xs font-medium">
             Description
@@ -350,11 +474,9 @@ export function EstimatorDetailsPanel({
         )}
 
         {/* ─── Inputs ─── */}
-        <div className="flex items-center justify-between mt-2">
-          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            Inputs
-          </h3>
-        </div>
+        <h3 className="mt-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Inputs
+        </h3>
         <p className="text-xs text-muted-foreground">
           Parameters required to run this estimator. Types: number, boolean, product.
         </p>
@@ -367,7 +489,6 @@ export function EstimatorDetailsPanel({
             onDelete={handleDeleteInput}
           />
         ))}
-
         <Button
           variant="outline"
           size="sm"
@@ -379,11 +500,9 @@ export function EstimatorDetailsPanel({
         </Button>
 
         {/* ─── Outputs ─── */}
-        <div className="flex items-center justify-between mt-4">
-          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            Outputs
-          </h3>
-        </div>
+        <h3 className="mt-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Outputs
+        </h3>
         <p className="text-xs text-muted-foreground">
           Variables produced by the calculation. Reference inputs with <code className="font-mono bg-muted px-1 rounded">@input_key</code>.
         </p>
@@ -402,7 +521,6 @@ export function EstimatorDetailsPanel({
             onDelete={handleDeleteOutput}
           />
         ))}
-
         <Button
           variant="outline"
           size="sm"
@@ -412,6 +530,147 @@ export function EstimatorDetailsPanel({
           <Plus className="w-3.5 h-3.5 mr-1.5" />
           Add output
         </Button>
+
+        {/* ─── Execution context ─── */}
+        {binding && (
+          <>
+            <h3 className="mt-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Execution context
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              Run once, or loop over each iteration of a repeatable step.
+            </p>
+            <Select
+              value={mapOverStep ?? "__global__"}
+              onValueChange={(v) => setMapOverStep(v === "__global__" ? null : v)}
+            >
+              <SelectTrigger className="h-8 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__global__">Global execution</SelectItem>
+                {repeatableSteps.length === 0 ? (
+                  <SelectItem value="__none__" disabled>
+                    No repeatable steps in this flow
+                  </SelectItem>
+                ) : (
+                  repeatableSteps.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      Loop over: {s.title}
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </>
+        )}
+
+        {/* ─── Argument mapping ─── */}
+        {binding && hasInputs && (
+          <>
+            <h3 className="mt-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Arguments
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              Map each input to a flow field or another binding's output.
+            </p>
+
+            {effectiveInputs.map((input) => {
+              const numericOnly = input.parameter_type.kind !== "product"
+              return (
+                <div
+                  key={`wiring-${input.id}`}
+                  className="flex flex-col gap-1 rounded-md border border-border/60 px-3 py-2"
+                >
+                  <Label className="text-xs">
+                    <span className="font-mono font-semibold" style={{ color: EMERALD }}>
+                      {input.key}
+                    </span>
+                    <span className="ml-2 text-[10px] text-muted-foreground">
+                      : {input.parameter_type.kind}
+                      {input.parameter_type.kind === "product" && input.parameter_type.label_filter
+                        ? ` (${input.parameter_type.label_filter})`
+                        : ""}
+                    </span>
+                  </Label>
+                  <Select
+                    value={currentSelectValue(input.key) || "__unset__"}
+                    onValueChange={(raw) => handleSourceChange(input.key, raw, numericOnly)}
+                  >
+                    <SelectTrigger className="h-8 text-sm">
+                      <SelectValue placeholder="Not mapped" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__unset__">— Not mapped —</SelectItem>
+                      {allFields
+                        .filter((f) => !numericOnly || f.numeric)
+                        .map((f) => (
+                          <SelectItem key={`f-${f.id}`} value={`field:${f.id}`}>
+                            Field: {f.label || f.key}
+                          </SelectItem>
+                        ))}
+                      {otherBindings.flatMap((b) =>
+                        Object.keys(b.outputs_reduce_strategy as ReduceMap).map((key) => (
+                          <SelectItem
+                            key={`b-${b.id}-${key}`}
+                            value={`binding:${b.id}.${key}`}
+                          >
+                            Binding {b.id.slice(0, 8)} → {key}
+                          </SelectItem>
+                        )),
+                      )}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )
+            })}
+          </>
+        )}
+
+        {/* ─── Reduce ─── */}
+        {binding && showReduce && (
+          <>
+            <h3 className="mt-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Reduce
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              How to aggregate each output across iterations of the loop.
+            </p>
+
+            {effectiveOutputs.map((out) => (
+              <div
+                key={`reduce-${out.id}`}
+                className="flex items-center gap-2 rounded-md border border-border/60 px-3 py-2"
+              >
+                <span
+                  className="text-xs font-mono font-semibold flex-1 min-w-0 truncate"
+                  style={{ color: ROSE }}
+                >
+                  {out.key}
+                </span>
+                <Select
+                  value={reduceMap[out.key] ?? "first"}
+                  onValueChange={(v) =>
+                    setReduceStrategy(out.key, v as Schemas.AggregationStrategyDto)
+                  }
+                >
+                  <SelectTrigger className="h-7 w-32 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="sum">Sum</SelectItem>
+                    <SelectItem value="average">Average</SelectItem>
+                    <SelectItem value="max">Max</SelectItem>
+                    <SelectItem value="min">Min</SelectItem>
+                    <SelectItem value="count">Count</SelectItem>
+                    <SelectItem value="first">First</SelectItem>
+                    <SelectItem value="last">Last</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            ))}
+          </>
+        )}
       </div>
 
       <div className="flex gap-2 px-5 py-4 border-t shrink-0">

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
@@ -157,6 +157,25 @@ export function EstimatorDetailsPanel({
     [flow.steps],
   )
 
+  // Resolve the *current* (draft-aware) key for an input id — bindings are
+  // keyed by input.key, so renaming an input must rekey the binding's
+  // inputs_mapping in step. Same idea for outputs → reduceMap.
+  function currentInputKey(inputId: string): string | null {
+    const temp = drafts.pendingInputAdds.find((v) => v.id === inputId)
+    if (temp) return temp.key
+    const edit = drafts.inputEdits[inputId]?.key
+    const server = estimator.inputs.find((v) => v.id === inputId)
+    return edit ?? server?.key ?? null
+  }
+
+  function currentOutputKey(outputId: string): string | null {
+    const temp = drafts.pendingOutputAdds.find((v) => v.id === outputId)
+    if (temp) return temp.key
+    const edit = drafts.outputEdits[outputId]?.key
+    const server = estimator.outputs.find((v) => v.id === outputId)
+    return edit ?? server?.key ?? null
+  }
+
   // ─── Validation + dirty detection ────────────────────────────────────────
   const normalizedName = nameDisplay.trim().replace(/\s+/g, "_")
   const nameValid = /^[A-Za-z0-9_]+$/.test(normalizedName)
@@ -192,93 +211,129 @@ export function EstimatorDetailsPanel({
     isDirty && nameValid && !duplicateName && normalizedName.length > 0
 
   // ─── Save ────────────────────────────────────────────────────────────────
-  function handleSave() {
+  async function handleSave() {
     if (!canSave) return
+
+    // Estimator signature must land BEFORE the binding update — binding
+    // validation runs against the live estimator state on the server, so a
+    // rename-then-rewire flow would fail the binding PUT otherwise.
+    const signaturePromises: Promise<unknown>[] = []
 
     if (nameDirty || descDirty) {
       const body: Schemas.UpdateEstimatorRequest = {}
       if (nameDirty) body.name = normalizedName
       if (descDirty) body.description = drafts.descDraft ?? ""
-      updateEstimator.mutate(
-        { path: { estimator_id: estimator.id }, body },
-        { onError: (err) => toast.error(`Update failed: ${err.message}`) },
+      signaturePromises.push(
+        updateEstimator.mutateAsync({ path: { estimator_id: estimator.id }, body }),
       )
     }
 
     for (const v of drafts.pendingInputAdds) {
-      addInput.mutate(
-        {
+      signaturePromises.push(
+        addInput.mutateAsync({
           path: { estimator_id: estimator.id },
           body: {
             key: v.key,
             description: v.description || null,
             parameter_type: v.parameter_type,
           },
-        },
-        { onError: (err) => toast.error(`Add input failed: ${err.message}`) },
+        }),
       )
     }
     for (const [inputId, patch] of Object.entries(drafts.inputEdits)) {
-      const body: Schemas.UpdateInputRequest = {
-        key: patch.key,
-        description: patch.description ?? null,
-        parameter_type: patch.parameter_type ?? null,
-      }
-      updateInput.mutate(
-        { path: { estimator_id: estimator.id, input_id: inputId }, body },
-        { onError: (err) => toast.error(`Input update failed: ${err.message}`) },
+      signaturePromises.push(
+        updateInput.mutateAsync({
+          path: { estimator_id: estimator.id, input_id: inputId },
+          body: {
+            key: patch.key,
+            description: patch.description ?? null,
+            parameter_type: patch.parameter_type ?? null,
+          },
+        }),
       )
     }
     for (const inputId of drafts.pendingInputDeletes) {
-      removeInput.mutate(
-        { path: { estimator_id: estimator.id, input_id: inputId } },
-        { onError: (err) => toast.error(`Delete input failed: ${err.message}`) },
+      signaturePromises.push(
+        removeInput.mutateAsync({
+          path: { estimator_id: estimator.id, input_id: inputId },
+        }),
       )
     }
 
     for (const v of drafts.pendingOutputAdds) {
-      addOutput.mutate(
-        {
+      signaturePromises.push(
+        addOutput.mutateAsync({
           path: { estimator_id: estimator.id },
           body: {
             key: v.key,
             expression: v.expression || "0",
             description: v.description || null,
           },
-        },
-        { onError: (err) => toast.error(`Add output failed: ${err.message}`) },
+        }),
       )
     }
     for (const [outputId, patch] of Object.entries(drafts.outputEdits)) {
-      const body: Schemas.UpdateOutputRequest = {
-        key: patch.key,
-        expression: patch.expression,
-        description: patch.description ?? null,
-      }
-      updateOutput.mutate(
-        { path: { estimator_id: estimator.id, output_id: outputId }, body },
-        { onError: (err) => toast.error(`Output update failed: ${err.message}`) },
+      signaturePromises.push(
+        updateOutput.mutateAsync({
+          path: { estimator_id: estimator.id, output_id: outputId },
+          body: {
+            key: patch.key,
+            expression: patch.expression,
+            description: patch.description ?? null,
+          },
+        }),
       )
     }
     for (const outputId of drafts.pendingOutputDeletes) {
-      removeOutput.mutate(
-        { path: { estimator_id: estimator.id, output_id: outputId } },
-        { onError: (err) => toast.error(`Delete output failed: ${err.message}`) },
+      signaturePromises.push(
+        removeOutput.mutateAsync({
+          path: { estimator_id: estimator.id, output_id: outputId },
+        }),
       )
     }
 
+    try {
+      await Promise.all(signaturePromises)
+    } catch (err) {
+      toast.error(`Signature update failed: ${(err as Error).message}`)
+      return
+    }
+
     if (bindingDirty && binding) {
-      updateBinding.mutate(
-        {
+      // Rebuild the mapping keyed strictly by the *current* input/output
+      // keys. This guards against any stale entries that the live rekey
+      // might have missed (double renames, server refetch races, etc.) and
+      // drops entries that point to deleted inputs/outputs.
+      const finalInputsMapping: InputsMap = {}
+      for (const inp of effectiveInputs) {
+        const serverKey = estimator.inputs.find((s) => s.id === inp.id)?.key
+        const entry =
+          inputsMapping[inp.key] ??
+          (serverKey ? inputsMapping[serverKey] : undefined)
+        if (entry) finalInputsMapping[inp.key] = entry
+      }
+
+      const finalReduceMap: ReduceMap = {}
+      for (const out of effectiveOutputs) {
+        const serverKey = estimator.outputs.find((s) => s.id === out.id)?.key
+        const strat =
+          reduceMap[out.key] ?? (serverKey ? reduceMap[serverKey] : undefined)
+        if (strat) finalReduceMap[out.key] = strat
+      }
+
+      try {
+        await updateBinding.mutateAsync({
           path: { flow_id: flowId, binding_id: binding.id },
           body: {
-            inputs_mapping: inputsMapping,
-            outputs_reduce_strategy: reduceMap,
+            inputs_mapping: finalInputsMapping,
+            outputs_reduce_strategy: finalReduceMap,
             map_over_step: mapOverStep,
           },
-        },
-        { onError: (err) => toast.error(`Wiring update failed: ${err.message}`) },
-      )
+        })
+      } catch (err) {
+        toast.error(`Wiring update failed: ${(err as Error).message}`)
+        return
+      }
     }
 
     drafts.clear()
@@ -294,8 +349,24 @@ export function EstimatorDetailsPanel({
     setReduceMap(serverReduceMap)
   }
 
-  // ─── Input/Output draft staging (unchanged) ──────────────────────────────
+  // ─── Input/Output draft staging ──────────────────────────────────────────
   function handleInputPatch(inputId: string, patch: Partial<Schemas.InputResponse>) {
+    // Rename cascade: input key changed → rekey any binding entry that used
+    // the previous key so the PUT body matches the new signature.
+    if (patch.key !== undefined) {
+      const oldKey = currentInputKey(inputId)
+      const newKey = patch.key
+      if (oldKey && newKey && oldKey !== newKey) {
+        setInputsMapping((prev) => {
+          if (!(oldKey in prev)) return prev
+          const next = { ...prev }
+          next[newKey] = next[oldKey]
+          delete next[oldKey]
+          return next
+        })
+      }
+    }
+
     if (inputId.startsWith(TEMP_PREFIX)) {
       const cur = drafts.pendingInputAdds.find((v) => v.id === inputId)
       if (!cur) return
@@ -331,15 +402,38 @@ export function EstimatorDetailsPanel({
   }
 
   function handleDeleteInput(inputId: string) {
+    const key = currentInputKey(inputId)
     if (inputId.startsWith(TEMP_PREFIX)) {
       drafts.removePendingInput(inputId)
     } else {
       drafts.markInputDelete(inputId)
     }
+    if (key) {
+      setInputsMapping((prev) => {
+        if (!(key in prev)) return prev
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    }
     setExpandedCardId((prev) => (prev === inputId ? null : prev))
   }
 
   function handleOutputPatch(outputId: string, patch: Partial<Schemas.OutputResponse>) {
+    if (patch.key !== undefined) {
+      const oldKey = currentOutputKey(outputId)
+      const newKey = patch.key
+      if (oldKey && newKey && oldKey !== newKey) {
+        setReduceMap((prev) => {
+          if (!(oldKey in prev)) return prev
+          const next = { ...prev }
+          next[newKey] = next[oldKey]
+          delete next[oldKey]
+          return next
+        })
+      }
+    }
+
     if (outputId.startsWith(TEMP_PREFIX)) {
       const cur = drafts.pendingOutputAdds.find((v) => v.id === outputId)
       if (!cur) return
@@ -374,10 +468,19 @@ export function EstimatorDetailsPanel({
   }
 
   function handleDeleteOutput(outputId: string) {
+    const key = currentOutputKey(outputId)
     if (outputId.startsWith(TEMP_PREFIX)) {
       drafts.removePendingOutput(outputId)
     } else {
       drafts.markOutputDelete(outputId)
+    }
+    if (key) {
+      setReduceMap((prev) => {
+        if (!(key in prev)) return prev
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
     }
     setExpandedCardId((prev) => (prev === outputId ? null : prev))
   }

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
@@ -62,6 +62,11 @@ export function EstimatorDetailsPanel({
   onClose: () => void
 }) {
   const [editingName, setEditingName] = useState(false)
+  // Accordion-style: only one input or output card expanded at a time.
+  const [expandedCardId, setExpandedCardId] = useState<string | null>(null)
+
+  const toggleCard = (id: string) =>
+    setExpandedCardId((prev) => (prev === id ? null : id))
 
   const drafts = useEstimatorDraftStore()
 
@@ -78,6 +83,11 @@ export function EstimatorDetailsPanel({
   useEffect(() => {
     setEditingName(false)
   }, [estimator.id, estimator.name, estimator.description])
+
+  // Reset the accordion when switching estimators.
+  useEffect(() => {
+    setExpandedCardId(null)
+  }, [estimator.id])
 
   const updateEstimator = useUpdateEstimator(flowId, estimator.id)
   const addInput = useAddInput(flowId, estimator.id)
@@ -317,14 +327,16 @@ export function EstimatorDetailsPanel({
       description: "",
       parameter_type: { kind: "number" },
     })
+    setExpandedCardId(tempId)
   }
 
   function handleDeleteInput(inputId: string) {
     if (inputId.startsWith(TEMP_PREFIX)) {
       drafts.removePendingInput(inputId)
-      return
+    } else {
+      drafts.markInputDelete(inputId)
     }
-    drafts.markInputDelete(inputId)
+    setExpandedCardId((prev) => (prev === inputId ? null : prev))
   }
 
   function handleOutputPatch(outputId: string, patch: Partial<Schemas.OutputResponse>) {
@@ -358,14 +370,16 @@ export function EstimatorDetailsPanel({
       expression: "0",
       description: "",
     })
+    setExpandedCardId(tempId)
   }
 
   function handleDeleteOutput(outputId: string) {
     if (outputId.startsWith(TEMP_PREFIX)) {
       drafts.removePendingOutput(outputId)
-      return
+    } else {
+      drafts.markOutputDelete(outputId)
     }
-    drafts.markOutputDelete(outputId)
+    setExpandedCardId((prev) => (prev === outputId ? null : prev))
   }
 
   const ownInputKeys = effectiveInputs.map((i) => i.key)
@@ -485,6 +499,8 @@ export function EstimatorDetailsPanel({
           <InputCard
             key={i.id}
             input={i}
+            expanded={expandedCardId === i.id}
+            onToggle={() => toggleCard(i.id)}
             onUpdate={handleInputPatch}
             onDelete={handleDeleteInput}
           />
@@ -511,6 +527,8 @@ export function EstimatorDetailsPanel({
           <OutputCard
             key={o.id}
             output={o}
+            expanded={expandedCardId === o.id}
+            onToggle={() => toggleCard(o.id)}
             ownEstimatorName={estimator.name}
             ownInputKeys={ownInputKeys}
             ownOutputKeys={ownOutputKeys.filter((k) => k !== o.key)}

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/input-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/input-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Trash2 } from "lucide-react"
 import type { Schemas } from "@/api/api.client"
 import {
@@ -42,18 +42,22 @@ function buildParamType(kind: ParamKind, labelFilter: string): Schemas.Estimator
 
 export function InputCard({
   input,
+  expanded,
+  onToggle,
   onUpdate,
   onDelete,
 }: {
   input: Schemas.InputResponse
+  expanded: boolean
+  onToggle: () => void
   onUpdate: (inputId: string, patch: Partial<Schemas.InputResponse>) => void
   onDelete: (inputId: string) => void
 }) {
-  const [expanded, setExpanded] = useState(false)
   const [keyDraft, setKeyDraft] = useState(input.key)
   const [descDraft, setDescDraft] = useState(input.description)
   const [kindDraft, setKindDraft] = useState<ParamKind>(paramKindOf(input.parameter_type))
   const [labelFilterDraft, setLabelFilterDraft] = useState(paramLabelFilter(input.parameter_type))
+  const rootRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     setKeyDraft(input.key)
@@ -61,6 +65,13 @@ export function InputCard({
     setKindDraft(paramKindOf(input.parameter_type))
     setLabelFilterDraft(paramLabelFilter(input.parameter_type))
   }, [input.id, input.key, input.description, input.parameter_type])
+
+  // Scroll into view when the parent just expanded this card.
+  useEffect(() => {
+    if (expanded) {
+      rootRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })
+    }
+  }, [expanded])
 
   const commitKey = () => {
     const trimmed = keyDraft.trim()
@@ -85,9 +96,9 @@ export function InputCard({
   }
 
   return (
-    <div className="rounded-md border border-border/60 overflow-hidden shrink-0">
+    <div ref={rootRef} className="rounded-md border border-border/60 overflow-hidden shrink-0">
       <div className="flex items-center gap-1.5 px-3 py-2 bg-muted/30">
-        <button className="flex-1 text-left" onClick={() => setExpanded((p) => !p)}>
+        <button className="flex-1 text-left" onClick={onToggle}>
           <span className="text-sm font-mono font-semibold" style={{ color: EMERALD }}>
             {input.key}
           </span>

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/input-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/input-card.tsx
@@ -85,7 +85,7 @@ export function InputCard({
   }
 
   return (
-    <div className="rounded-md border border-border/60 overflow-hidden">
+    <div className="rounded-md border border-border/60 overflow-hidden shrink-0">
       <div className="flex items-center gap-1.5 px-3 py-2 bg-muted/30">
         <button className="flex-1 text-left" onClick={() => setExpanded((p) => !p)}>
           <span className="text-sm font-mono font-semibold" style={{ color: EMERALD }}>

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
@@ -38,6 +38,8 @@ type Suggestion = {
 
 export function OutputCard({
   output,
+  expanded,
+  onToggle,
   ownEstimatorName,
   ownInputKeys,
   ownOutputKeys,
@@ -48,6 +50,8 @@ export function OutputCard({
   onDelete,
 }: {
   output: Schemas.OutputResponse
+  expanded: boolean
+  onToggle: () => void
   ownEstimatorName: string
   ownInputKeys: string[]
   ownOutputKeys: string[]
@@ -57,10 +61,10 @@ export function OutputCard({
   onUpdate: (outputId: string, patch: Partial<Schemas.OutputResponse>) => void
   onDelete: (outputId: string) => void
 }) {
-  const [expanded, setExpanded] = useState(!output.expression)
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [suggestionFilter, setSuggestionFilter] = useState("")
   const exprRef = useRef<HTMLTextAreaElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
 
   const displayExpression = idsToNames(output.expression, estimatorsIndex)
 
@@ -76,6 +80,12 @@ export function OutputCard({
     pickedIdsRef.current = new Map()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [output.id, output.key, output.expression, output.description])
+
+  useEffect(() => {
+    if (expanded) {
+      rootRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })
+    }
+  }, [expanded])
 
   const [dropdownPos, setDropdownPos] = useState<{
     top: number
@@ -240,9 +250,9 @@ export function OutputCard({
   }
 
   return (
-    <div className="rounded-md border border-border/60 overflow-hidden shrink-0">
+    <div ref={rootRef} className="rounded-md border border-border/60 overflow-hidden shrink-0">
       <div className="flex items-center gap-1.5 px-3 py-2 bg-muted/30">
-        <button className="flex-1 text-left" onClick={() => setExpanded((p) => !p)}>
+        <button className="flex-1 text-left" onClick={onToggle}>
           <span className="text-sm font-mono font-semibold" style={{ color: ROSE }}>
             {output.key}
           </span>

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
@@ -240,7 +240,7 @@ export function OutputCard({
   }
 
   return (
-    <div className="rounded-md border border-border/60 overflow-hidden">
+    <div className="rounded-md border border-border/60 overflow-hidden shrink-0">
       <div className="flex items-center gap-1.5 px-3 py-2 bg-muted/30">
         <button className="flex-1 text-left" onClick={() => setExpanded((p) => !p)}>
           <span className="text-sm font-mono font-semibold" style={{ color: ROSE }}>


### PR DESCRIPTION
This pull request introduces support for flow estimator bindings in the FerrisQuote webapp, including new API endpoints, React hooks, and UI integration. It adds hooks and logic to fetch, create, update, and delete bindings, ensures that each estimator has a binding when opened, and passes binding data into the estimator details panel. Additionally, it improves the input/output card components by making their expansion state controlled by the parent and enabling them to scroll into view when expanded.

**API and Data Layer Enhancements:**

* Added new API types and endpoints for evaluating flow bindings (`EvaluateBindingsRequest`, `FlowEvaluationResponse`, `FlowPreviewResponse`) and registered them in the client (`api.client.ts`). [[1]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R168) [[2]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R181-R186) [[3]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R537-R556) [[4]](diffhunk://#diff-af54411f1fc1b245586fef9a437878e82c7b985824f909ee49451fe27d2108f6R642-R643)
* Implemented React Query hooks for CRUD operations on bindings and for evaluating/previewing flow bindings (`useBindings`, `useCreateBinding`, `useUpdateBinding`, `useDeleteBinding`, `useEvaluateBindings`, `usePreviewFlow` in `bindings.api.ts`).

**UI and State Management:**

* Integrated bindings into the flow canvas and edit panel: bindings are fetched and available in both, and the estimator details panel receives the relevant binding and other bindings as props (`flow-canvas.tsx`, `flow-edit-panel.tsx`). [[1]](diffhunk://#diff-cc9df7bae303bd3ea13560de68be1ef75a931bfb8e53ce753857c0f4e944912eR31) [[2]](diffhunk://#diff-cc9df7bae303bd3ea13560de68be1ef75a931bfb8e53ce753857c0f4e944912eR473-R476) [[3]](diffhunk://#diff-cc9df7bae303bd3ea13560de68be1ef75a931bfb8e53ce753857c0f4e944912eR493) [[4]](diffhunk://#diff-cc9df7bae303bd3ea13560de68be1ef75a931bfb8e53ce753857c0f4e944912eR552-R565) [[5]](diffhunk://#diff-d89604a5307bd4df67a6b7be24aba11a8abe9c842ee270236d1cdc85903f39dbR12) [[6]](diffhunk://#diff-d89604a5307bd4df67a6b7be24aba11a8abe9c842ee270236d1cdc85903f39dbR40-R43) [[7]](diffhunk://#diff-d89604a5307bd4df67a6b7be24aba11a8abe9c842ee270236d1cdc85903f39dbR65-R74) [[8]](diffhunk://#diff-d89604a5307bd4df67a6b7be24aba11a8abe9c842ee270236d1cdc85903f39dbL172-R192)
* When an estimator node is opened, the app ensures a binding exists for it, creating one if necessary before showing the details panel.

**Component Improvements:**

* Refactored `InputCard` and `OutputCard` to receive `expanded` and `onToggle` props from their parent, making their expansion state controlled rather than internal. [[1]](diffhunk://#diff-563d28bb2aa23fac89296bbca912074377bbb7df61f4f7b9ce750054083a4dd1R45-R60) [[2]](diffhunk://#diff-563d28bb2aa23fac89296bbca912074377bbb7df61f4f7b9ce750054083a4dd1L88-R101) [[3]](diffhunk://#diff-c648a00429a7044e42e26220f5108d55877637c34e4e46016dfd54dfa0c97accR41-R42) [[4]](diffhunk://#diff-c648a00429a7044e42e26220f5108d55877637c34e4e46016dfd54dfa0c97accR53-R54) [[5]](diffhunk://#diff-c648a00429a7044e42e26220f5108d55877637c34e4e46016dfd54dfa0c97accL243-R255)
* Added logic to both cards to scroll into view smoothly when expanded, improving user experience when editing long lists of inputs/outputs. [[1]](diffhunk://#diff-563d28bb2aa23fac89296bbca912074377bbb7df61f4f7b9ce750054083a4dd1R69-R75) [[2]](diffhunk://#diff-c648a00429a7044e42e26220f5108d55877637c34e4e46016dfd54dfa0c97accR84-R89)

These changes collectively add robust support for estimator bindings and improve the flexibility and usability of the flow editing UI.