### PR TITLE
feat(front): make user-friendly UX estimator edition

### DIFF
--- a/apps/ferrisquote-webapp/src/App.jsx
+++ b/apps/ferrisquote-webapp/src/App.jsx
@@ -16,7 +16,7 @@ function App() {
           <Route path={QUOTES_URL()} element={<Navigate to={`${QUOTES_URL()}/flows`} replace />} />
         </Route>
       </Routes>
-      <Toaster position="bottom-right" richColors closeButton />
+      <Toaster position="top-center" richColors closeButton />
     </>
   )
 }

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
@@ -1,6 +1,7 @@
 import {
   Background,
   Controls,
+  MarkerType,
   ReactFlow,
   useReactFlow,
   type Edge,
@@ -106,6 +107,7 @@ function extractExprRefs(expression: string): ExprRef[] {
 function buildGraph(
   flow: Schemas.FlowResponse,
   estimators: Schemas.EstimatorResponse[],
+  bindings: Schemas.BindingResponse[],
   expandedStepIds: Set<string>,
   linkingField: false | "form" | "quick",
   dropIndicatorIndex: number | null,
@@ -449,6 +451,62 @@ function buildGraph(
     }
   }
 
+  // ─── Binding input wiring edges (field → estimator input handle) ────────
+  // Draw a green arrow from each flow field that is mapped into an
+  // estimator's input via a binding. Matches the emerald handle color used
+  // by `EstimatorNode` for input targets.
+  const INPUT_COLOR = "hsl(158, 64%, 52%)"
+  const estById = new Map<string, Schemas.EstimatorResponse>(
+    estimators.map((e) => [e.id, e]),
+  )
+
+  for (const binding of bindings) {
+    const est = estById.get(binding.estimator_id)
+    if (!est) continue
+    const estimatorNodeId = `estimator-${binding.estimator_id}`
+    // utoipa widens inputs_mapping to Record<string, unknown> — cast locally
+    const mapping = binding.inputs_mapping as Record<
+      string,
+      Schemas.InputBindingValueDto
+    >
+
+    for (const [inputKey, source] of Object.entries(mapping)) {
+      if (source.source !== "field") continue
+      const input = est.inputs.find((i) => i.key === inputKey)
+      if (!input) continue
+      const fieldInfo = flow.steps
+        .flatMap((s) => s.fields.map((f) => ({ f, stepId: s.id })))
+        .find((x) => x.f.id === source.field_id)
+      if (!fieldInfo) continue
+
+      const stepExpanded = expandedStepIds.has(fieldInfo.stepId)
+      const sourceId = stepExpanded
+        ? `field-${fieldInfo.f.id}`
+        : fieldInfo.stepId
+
+      edges.push({
+        id: `e-bind-${binding.id}-${input.id}`,
+        source: sourceId,
+        sourceHandle: "right",
+        target: estimatorNodeId,
+        targetHandle: `target-input-${input.id}`,
+        type: "smoothstep",
+        animated: false,
+        style: {
+          strokeWidth: 2,
+          stroke: INPUT_COLOR,
+          opacity: 0.85,
+          transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+        },
+        markerEnd: { type: MarkerType.ArrowClosed, color: INPUT_COLOR },
+        label: inputKey,
+        labelStyle: { fill: INPUT_COLOR, fontSize: 10, fontWeight: 600 },
+        labelBgStyle: { fill: "var(--background)", fillOpacity: 0.9 },
+        labelBgPadding: [4, 2] as [number, number],
+      })
+    }
+  }
+
   return { nodes, edges, stepPositions }
 }
 
@@ -616,13 +674,20 @@ function FlowCanvasImpl({ flowId, panelState, setPanelState }: Props) {
   }
 
   function handlePaneClick() {
-    if (linkingField) setLinkingField(false)
+    // Linking mode always takes priority — a blank-canvas click cancels it
+    // rather than closing the edit panel.
+    if (linkingField) {
+      setLinkingField(false)
+      return
+    }
+    if (panelState) setPanelState(null)
   }
 
   const { nodes, edges, stepPositions } = flow
     ? buildGraph(
       flow,
       estimators,
+      bindings,
       expandedStepIds,
       linkingField,
       dropIndicatorIndex,

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
@@ -579,6 +579,7 @@ function FlowCanvasImpl({ flowId, panelState, setPanelState }: Props) {
     addStep,
     addField,
     createEstimator,
+    createBinding,
   })
   const { dropIndicatorIndex, onNodeDrag, onNodeDragStop } = useStepReorder(
     flow,

--- a/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/feature/flow-canvas.tsx
@@ -107,6 +107,7 @@ function extractExprRefs(expression: string): ExprRef[] {
 function buildGraph(
   flow: Schemas.FlowResponse,
   estimators: Schemas.EstimatorResponse[],
+  rawEstimators: Schemas.EstimatorResponse[],
   bindings: Schemas.BindingResponse[],
   expandedStepIds: Set<string>,
   linkingField: false | "form" | "quick",
@@ -451,17 +452,31 @@ function buildGraph(
     }
   }
 
-  // ─── Binding input wiring edges (field → estimator input handle) ────────
-  // Draw a green arrow from each flow field that is mapped into an
-  // estimator's input via a binding. Matches the emerald handle color used
-  // by `EstimatorNode` for input targets.
+  // ─── Binding input wiring edges ──────────────────────────────────────────
+  // Two kinds of edges depending on the source:
+  //   - Field → input: emerald (matches input handle color)
+  //   - Binding output → input (chaining): rose (matches output handle color)
   const INPUT_COLOR = "hsl(158, 64%, 52%)"
+  const OUTPUT_COLOR = "hsl(330, 80%, 60%)"
   const estById = new Map<string, Schemas.EstimatorResponse>(
     estimators.map((e) => [e.id, e]),
+  )
+  // Raw (non-overlaid) lookup — bindings persist input/output keys in their
+  // server form, so while a user is renaming an input locally the binding
+  // mapping still refers to the old key. Resolving the input through the
+  // raw estimator by old key gives us the stable id; we then use that id
+  // to target the handle on the overlaid node (handle ids are id-based, not
+  // key-based, so they don't flicker during renames).
+  const rawEstById = new Map<string, Schemas.EstimatorResponse>(
+    rawEstimators.map((e) => [e.id, e]),
+  )
+  const bindingById = new Map<string, Schemas.BindingResponse>(
+    bindings.map((b) => [b.id, b]),
   )
 
   for (const binding of bindings) {
     const est = estById.get(binding.estimator_id)
+    const rawEst = rawEstById.get(binding.estimator_id)
     if (!est) continue
     const estimatorNodeId = `estimator-${binding.estimator_id}`
     // utoipa widens inputs_mapping to Record<string, unknown> — cast locally
@@ -471,39 +486,85 @@ function buildGraph(
     >
 
     for (const [inputKey, source] of Object.entries(mapping)) {
-      if (source.source !== "field") continue
-      const input = est.inputs.find((i) => i.key === inputKey)
+      // Prefer raw match (the binding's key is still the server-side one
+      // during an in-flight local rename); fall back to the overlaid view
+      // so freshly added inputs still wire up.
+      const input =
+        rawEst?.inputs.find((i) => i.key === inputKey) ??
+        est.inputs.find((i) => i.key === inputKey)
       if (!input) continue
-      const fieldInfo = flow.steps
-        .flatMap((s) => s.fields.map((f) => ({ f, stepId: s.id })))
-        .find((x) => x.f.id === source.field_id)
-      if (!fieldInfo) continue
 
-      const stepExpanded = expandedStepIds.has(fieldInfo.stepId)
-      const sourceId = stepExpanded
-        ? `field-${fieldInfo.f.id}`
-        : fieldInfo.stepId
+      if (source.source === "field") {
+        const fieldInfo = flow.steps
+          .flatMap((s) => s.fields.map((f) => ({ f, stepId: s.id })))
+          .find((x) => x.f.id === source.field_id)
+        if (!fieldInfo) continue
 
-      edges.push({
-        id: `e-bind-${binding.id}-${input.id}`,
-        source: sourceId,
-        sourceHandle: "right",
-        target: estimatorNodeId,
-        targetHandle: `target-input-${input.id}`,
-        type: "smoothstep",
-        animated: false,
-        style: {
-          strokeWidth: 2,
-          stroke: INPUT_COLOR,
-          opacity: 0.85,
-          transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
-        },
-        markerEnd: { type: MarkerType.ArrowClosed, color: INPUT_COLOR },
-        label: inputKey,
-        labelStyle: { fill: INPUT_COLOR, fontSize: 10, fontWeight: 600 },
-        labelBgStyle: { fill: "var(--background)", fillOpacity: 0.9 },
-        labelBgPadding: [4, 2] as [number, number],
-      })
+        const stepExpanded = expandedStepIds.has(fieldInfo.stepId)
+        const sourceId = stepExpanded
+          ? `field-${fieldInfo.f.id}`
+          : fieldInfo.stepId
+
+        edges.push({
+          id: `e-bind-${binding.id}-${input.id}`,
+          source: sourceId,
+          sourceHandle: "right",
+          target: estimatorNodeId,
+          targetHandle: `target-input-${input.id}`,
+          type: "smoothstep",
+          animated: false,
+          style: {
+            strokeWidth: 2,
+            stroke: INPUT_COLOR,
+            opacity: 0.85,
+            transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+          },
+          markerEnd: { type: MarkerType.ArrowClosed, color: INPUT_COLOR },
+          label: inputKey,
+          labelStyle: { fill: INPUT_COLOR, fontSize: 10, fontWeight: 600 },
+          labelBgStyle: { fill: "var(--background)", fillOpacity: 0.9 },
+          labelBgPadding: [4, 2] as [number, number],
+        })
+      } else if (source.source === "binding_output") {
+        const upstream = bindingById.get(source.binding_id)
+        if (!upstream) continue
+        const upstreamEst = estById.get(upstream.estimator_id)
+        const upstreamRaw = rawEstById.get(upstream.estimator_id)
+        if (!upstreamEst) continue
+        // Same raw-first fallback as inputs — output keys on the binding
+        // reflect server state, so during a local rename the raw estimator
+        // owns the stable id we need for the handle.
+        const upstreamOutput =
+          upstreamRaw?.outputs.find((o) => o.key === source.output_key) ??
+          upstreamEst.outputs.find((o) => o.key === source.output_key)
+        if (!upstreamOutput) continue
+
+        const upstreamNodeId = `estimator-${upstream.estimator_id}`
+        // Self-chain (binding pointing to itself) makes no sense and would
+        // fail backend validation — skip to avoid visual noise.
+        if (upstreamNodeId === estimatorNodeId) continue
+
+        edges.push({
+          id: `e-bind-chain-${binding.id}-${input.id}`,
+          source: upstreamNodeId,
+          sourceHandle: `source-${upstreamOutput.id}`,
+          target: estimatorNodeId,
+          targetHandle: `target-input-${input.id}`,
+          type: "smoothstep",
+          animated: false,
+          style: {
+            strokeWidth: 2,
+            stroke: OUTPUT_COLOR,
+            opacity: 0.85,
+            transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+          },
+          markerEnd: { type: MarkerType.ArrowClosed, color: OUTPUT_COLOR },
+          label: `${source.output_key} → ${inputKey}`,
+          labelStyle: { fill: OUTPUT_COLOR, fontSize: 10, fontWeight: 600 },
+          labelBgStyle: { fill: "var(--background)", fillOpacity: 0.9 },
+          labelBgPadding: [4, 2] as [number, number],
+        })
+      }
     }
   }
 
@@ -688,6 +749,7 @@ function FlowCanvasImpl({ flowId, panelState, setPanelState }: Props) {
     ? buildGraph(
       flow,
       estimators,
+      rawEstimators,
       bindings,
       expandedStepIds,
       linkingField,

--- a/apps/ferrisquote-webapp/src/pages/flows/hooks/use-canvas-drag-drop.ts
+++ b/apps/ferrisquote-webapp/src/pages/flows/hooks/use-canvas-drag-drop.ts
@@ -36,6 +36,22 @@ type CreateEstimatorMutation = (
   },
 ) => void
 
+type CreateBindingMutation = (
+  params: {
+    path: { flow_id: string }
+    body: {
+      estimator_id: string
+      inputs_mapping: Record<string, never>
+      map_over_step: null
+      outputs_reduce_strategy: Record<string, never>
+    }
+  },
+  options?: {
+    onSuccess?: (data: unknown) => void
+    onError?: (err: Error) => void
+  },
+) => void
+
 /**
  * Canvas-level drag-and-drop + quick-create flow. Exposes:
  * - `onDragOver` / `onDrop` handlers for the ReactFlow surface
@@ -56,6 +72,7 @@ export function useCanvasDragDrop(args: {
   addStep: AddStepMutation
   addField: AddFieldMutation
   createEstimator: CreateEstimatorMutation
+  createBinding: CreateBindingMutation
 }) {
   const {
     flowId,
@@ -69,6 +86,7 @@ export function useCanvasDragDrop(args: {
     addStep,
     addField,
     createEstimator,
+    createBinding,
   } = args
 
   const fieldCounter = useRef(0)
@@ -157,10 +175,22 @@ export function useCanvasDragDrop(args: {
           {
             onSuccess: (data) => {
               const estId = (data as { data?: { id?: string } })?.data?.id
-              if (estId) {
-                setPanelState({ mode: "estimator-details", estimatorId: estId })
-                setPendingFocusNodeId(`estimator-${estId}`)
-              }
+              if (!estId) return
+              // Match the click-to-open flow: silently provision an empty
+              // binding so the unified panel immediately shows the wiring
+              // + reduce sections (otherwise new estimators would open with
+              // a signature-only view, inconsistent with existing ones).
+              createBinding({
+                path: { flow_id: flowId },
+                body: {
+                  estimator_id: estId,
+                  inputs_mapping: {},
+                  map_over_step: null,
+                  outputs_reduce_strategy: {},
+                },
+              })
+              setPanelState({ mode: "estimator-details", estimatorId: estId })
+              setPendingFocusNodeId(`estimator-${estId}`)
             },
             onError: (err) => toast.error(`Failed to create estimator: ${err.message}`),
           },
@@ -173,6 +203,7 @@ export function useCanvasDragDrop(args: {
       getNodes,
       addStep,
       createEstimator,
+      createBinding,
       estimators,
       quickCreateField,
       setExpandedStepIds,

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
@@ -146,11 +146,70 @@ export function EstimatorDetailsPanel({
           key: f.key,
           label: f.label,
           stepId: s.id,
+          stepTitle: s.title,
+          stepRepeatable: s.is_repeatable,
           numeric: f.config.type === "number",
         })),
       ),
     [flow.steps],
   )
+
+  // A field is usable only if:
+  // - its owning step is not repeatable, OR
+  // - the binding's execution context loops over that exact step.
+  // Otherwise the field has N values at run time and picking one would be
+  // ambiguous — block it at the UI level to keep pipelines correct.
+  function fieldAllowedByContext(field: { stepId: string; stepRepeatable: boolean }): boolean {
+    if (!field.stepRepeatable) return true
+    return mapOverStep === field.stepId
+  }
+
+  /** Pull bare `@field_key` tokens from an expression. Cross-refs
+   *  (`@#<uuid>.name`) are stripped first so only flow-field candidates
+   *  remain. Results include inputs/outputs too — callers intersect with
+   *  the actual flow field keys before using. */
+  function extractBareRefs(expr: string): string[] {
+    const stripped = expr.replace(/@#[A-Za-z0-9-]+\.[A-Za-z0-9_]+/g, "")
+    const keys = new Set<string>()
+    const re = /@([A-Za-z0-9_]+)/g
+    let m: RegExpExecArray | null
+    while ((m = re.exec(stripped)) !== null) keys.add(m[1])
+    return [...keys]
+  }
+
+  // Repeatable steps that are currently "pinned" by some field usage —
+  // either in the binding's inputs_mapping or in any output expression.
+  // Changing map_over_step to anything else would break these references.
+  const pinnedRepeatableSteps = useMemo(() => {
+    const set = new Set<string>()
+    const fieldById = new Map(allFields.map((f) => [f.id, f]))
+    const fieldByKey = new Map(allFields.map((f) => [f.key, f]))
+
+    for (const src of Object.values(inputsMapping)) {
+      if (src.source !== "field") continue
+      const meta = fieldById.get(src.field_id)
+      if (meta?.stepRepeatable) set.add(meta.stepId)
+    }
+
+    for (const out of effectiveOutputs) {
+      for (const token of extractBareRefs(out.expression)) {
+        const meta = fieldByKey.get(token)
+        if (meta?.stepRepeatable) set.add(meta.stepId)
+      }
+    }
+    return set
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputsMapping, effectiveOutputs, allFields])
+
+  function contextOptionAllowed(candidate: string | null): boolean {
+    // Global: only if nothing pins a repeatable step
+    if (candidate === null) return pinnedRepeatableSteps.size === 0
+    // Specific step: allowed iff no OTHER pinned step exists
+    for (const s of pinnedRepeatableSteps) {
+      if (s !== candidate) return false
+    }
+    return true
+  }
 
   const repeatableSteps = useMemo(
     () => flow.steps.filter((s) => s.is_repeatable),
@@ -514,6 +573,12 @@ export function EstimatorDetailsPanel({
         toast.error(`Field '${meta.key}' is not numeric`)
         return
       }
+      if (!fieldAllowedByContext(meta)) {
+        toast.error(
+          `Field '${meta.label || meta.key}' belongs to repeatable step '${meta.stepTitle}'. Set the execution context to loop over this step first.`,
+        )
+        return
+      }
       setInputsMapping((prev) => ({ ...prev, [inputKey]: { source: "field", field_id: fid } }))
     } else if (raw.startsWith("binding:")) {
       const [bid, okey] = raw.slice("binding:".length).split(".", 2)
@@ -663,7 +728,32 @@ export function EstimatorDetailsPanel({
             </p>
             <Select
               value={mapOverStep ?? "__global__"}
-              onValueChange={(v) => setMapOverStep(v === "__global__" ? null : v)}
+              onValueChange={(v) => {
+                const next = v === "__global__" ? null : v
+                setMapOverStep(next)
+                // When the loop context changes, any field mapping that pulls
+                // from a repeatable step other than the new context becomes
+                // ambiguous — drop it so the binding stays consistent.
+                setInputsMapping((prev) => {
+                  const out: InputsMap = {}
+                  for (const [k, src] of Object.entries(prev)) {
+                    if (src.source !== "field") {
+                      out[k] = src
+                      continue
+                    }
+                    const meta = allFields.find((f) => f.id === src.field_id)
+                    if (!meta) continue
+                    if (!meta.stepRepeatable || next === meta.stepId) {
+                      out[k] = src
+                    } else {
+                      toast.warning(
+                        `Input '${k}' was unlinked — field '${meta.label || meta.key}' requires looping over '${meta.stepTitle}'.`,
+                      )
+                    }
+                  }
+                  return out
+                })
+              }}
             >
               <SelectTrigger className="h-8 text-sm">
                 <SelectValue />
@@ -725,11 +815,20 @@ export function EstimatorDetailsPanel({
                       <SelectItem value="__unset__">— Not mapped —</SelectItem>
                       {allFields
                         .filter((f) => !numericOnly || f.numeric)
-                        .map((f) => (
-                          <SelectItem key={`f-${f.id}`} value={`field:${f.id}`}>
-                            Field: {f.label || f.key}
-                          </SelectItem>
-                        ))}
+                        .map((f) => {
+                          const allowed = fieldAllowedByContext(f)
+                          return (
+                            <SelectItem
+                              key={`f-${f.id}`}
+                              value={`field:${f.id}`}
+                              disabled={!allowed}
+                            >
+                              Field: {f.label || f.key}
+                              {f.stepRepeatable ? ` (${f.stepTitle})` : ""}
+                              {!allowed ? " — context required" : ""}
+                            </SelectItem>
+                          )
+                        })}
                       {otherBindings.flatMap((b) =>
                         Object.keys(b.outputs_reduce_strategy as ReduceMap).map((key) => (
                           <SelectItem

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/estimator-details-panel.tsx
@@ -700,7 +700,12 @@ export function EstimatorDetailsPanel({
             ownEstimatorName={estimator.name}
             ownInputKeys={ownInputKeys}
             ownOutputKeys={ownOutputKeys.filter((k) => k !== o.key)}
-            availableFieldKeys={availableFieldKeys}
+            // Hide fields whose step is repeatable but not the current
+            // loop context — using them in an expression would be ambiguous.
+            availableFieldKeys={availableFieldKeys.filter((key) => {
+              const meta = allFields.find((f) => f.key === key)
+              return !meta || fieldAllowedByContext(meta)
+            })}
             otherEstimators={otherEstimators}
             estimatorsIndex={estimatorsIndex}
             onUpdate={handleOutputPatch}
@@ -730,49 +735,56 @@ export function EstimatorDetailsPanel({
               value={mapOverStep ?? "__global__"}
               onValueChange={(v) => {
                 const next = v === "__global__" ? null : v
+                if (!contextOptionAllowed(next)) {
+                  const pinned = [...pinnedRepeatableSteps]
+                    .map((id) => flow.steps.find((s) => s.id === id)?.title ?? id)
+                    .join(", ")
+                  toast.error(
+                    `Cannot change execution context — fields from '${pinned}' are in use. Remove those references first.`,
+                  )
+                  return
+                }
                 setMapOverStep(next)
-                // When the loop context changes, any field mapping that pulls
-                // from a repeatable step other than the new context becomes
-                // ambiguous — drop it so the binding stays consistent.
-                setInputsMapping((prev) => {
-                  const out: InputsMap = {}
-                  for (const [k, src] of Object.entries(prev)) {
-                    if (src.source !== "field") {
-                      out[k] = src
-                      continue
-                    }
-                    const meta = allFields.find((f) => f.id === src.field_id)
-                    if (!meta) continue
-                    if (!meta.stepRepeatable || next === meta.stepId) {
-                      out[k] = src
-                    } else {
-                      toast.warning(
-                        `Input '${k}' was unlinked — field '${meta.label || meta.key}' requires looping over '${meta.stepTitle}'.`,
-                      )
-                    }
-                  }
-                  return out
-                })
               }}
             >
               <SelectTrigger className="h-8 text-sm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="__global__">Global execution</SelectItem>
+                <SelectItem
+                  value="__global__"
+                  disabled={!contextOptionAllowed(null)}
+                >
+                  Global execution
+                </SelectItem>
                 {repeatableSteps.length === 0 ? (
                   <SelectItem value="__none__" disabled>
                     No repeatable steps in this flow
                   </SelectItem>
                 ) : (
-                  repeatableSteps.map((s) => (
-                    <SelectItem key={s.id} value={s.id}>
-                      Loop over: {s.title}
-                    </SelectItem>
-                  ))
+                  repeatableSteps.map((s) => {
+                    const allowed = contextOptionAllowed(s.id)
+                    return (
+                      <SelectItem key={s.id} value={s.id} disabled={!allowed}>
+                        Loop over: {s.title}
+                        {!allowed ? " — conflicts with current usage" : ""}
+                      </SelectItem>
+                    )
+                  })
                 )}
               </SelectContent>
             </Select>
+            {pinnedRepeatableSteps.size > 0 && (
+              <p className="text-[11px] text-muted-foreground/80">
+                Context is locked while fields from{" "}
+                <code className="font-mono bg-muted px-1 rounded">
+                  {[...pinnedRepeatableSteps]
+                    .map((id) => flow.steps.find((s) => s.id === id)?.title ?? id)
+                    .join(", ")}
+                </code>{" "}
+                are referenced.
+              </p>
+            )}
           </>
         )}
 

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/input-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/input-card.tsx
@@ -177,6 +177,9 @@ export function InputCard({
                 value={labelFilterDraft}
                 onChange={(e) => setLabelFilterDraft(e.target.value)}
                 onBlur={commitLabelFilter}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") (e.target as HTMLInputElement).blur()
+                }}
               />
             </div>
           )}
@@ -189,6 +192,9 @@ export function InputCard({
               value={descDraft}
               onChange={(e) => setDescDraft(e.target.value)}
               onBlur={commitDesc}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") (e.target as HTMLInputElement).blur()
+              }}
             />
           </div>
         </div>

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
@@ -25,6 +25,8 @@ import {
 } from "@/pages/flows/lib/expression-refs"
 
 const ROSE = "hsl(330, 80%, 60%)"
+const EMERALD = "hsl(158, 64%, 52%)"
+const FIELD_ORANGE = "hsl(28, 85%, 55%)"
 const AGG_FUNCTIONS = ["SUM", "AVG", "COUNT_ITER"] as const
 
 type Suggestion = {
@@ -33,6 +35,7 @@ type Suggestion = {
   group: string
   groupLabel?: string
   isEstimator?: boolean
+  isInput?: boolean
   estimatorId?: string
 }
 
@@ -143,6 +146,7 @@ export function OutputCard({
         label: `@${k}`,
         insert: `@${k}`,
         group: "Inputs",
+        isInput: true,
       })),
     ...ownOutputKeys
       .filter((k) => k.toLowerCase().includes(filterLower))
@@ -309,22 +313,41 @@ export function OutputCard({
 
           <div className="flex flex-col gap-1 relative">
             <Label className="text-xs">Expression</Label>
-            <Textarea
-              ref={exprRef}
-              className="text-sm font-mono min-h-[60px] resize-none"
-              placeholder="e.g. @surface * @prix_unitaire * 1.2"
-              value={exprDraft}
-              onChange={(e) => handleExpressionChange(e.target.value)}
-              onFocus={() => {
-                if (!exprDraft) setShowSuggestions(true)
-              }}
-              onBlur={() => {
-                setTimeout(() => {
-                  setShowSuggestions(false)
-                  commitExpr()
-                }, 200)
-              }}
-            />
+            <div className="relative">
+              {/* Syntax-highlighted layer sits behind a transparent textarea.
+                  Both share identical font + padding so glyphs align. The
+                  textarea keeps all interaction (caret, selection, input);
+                  the layer only paints colored tokens. */}
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-0 whitespace-pre-wrap break-words font-mono text-sm px-3 py-2 rounded-md"
+                style={{ color: "transparent" }}
+              >
+                {renderHighlighted(
+                  exprDraft,
+                  ownInputKeys,
+                  ownOutputKeys,
+                  availableFieldKeys,
+                )}
+              </div>
+              <Textarea
+                ref={exprRef}
+                className="relative text-sm font-mono min-h-[60px] resize-none bg-transparent"
+                style={{ color: "transparent", caretColor: "currentColor" }}
+                placeholder="e.g. @surface * @prix_unitaire * 1.2"
+                value={exprDraft}
+                onChange={(e) => handleExpressionChange(e.target.value)}
+                onFocus={() => {
+                  if (!exprDraft) setShowSuggestions(true)
+                }}
+                onBlur={() => {
+                  setTimeout(() => {
+                    setShowSuggestions(false)
+                    commitExpr()
+                  }, 200)
+                }}
+              />
+            </div>
             {showSuggestions && suggestions.length > 0 && dropdownPos &&
               createPortal(
                 <div
@@ -354,8 +377,14 @@ export function OutputCard({
                         <button
                           className={cn(
                             "w-full text-left px-3 py-1.5 text-xs font-mono hover:bg-accent transition-colors",
-                            s.isEstimator && "text-[hsl(330,70%,60%)]",
                           )}
+                          style={{
+                            color: s.isInput
+                              ? EMERALD
+                              : s.isEstimator
+                                ? ROSE
+                                : undefined,
+                          }}
                           onMouseDown={(e) => {
                             e.preventDefault()
                             insertSuggestion(s)

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
@@ -453,6 +453,9 @@ export function OutputCard({
               value={descDraft}
               onChange={(e) => setDescDraft(e.target.value)}
               onBlur={commitDesc}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") (e.target as HTMLInputElement).blur()
+              }}
             />
           </div>
         </div>

--- a/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
+++ b/apps/ferrisquote-webapp/src/pages/flows/ui/edit-panel/output-card.tsx
@@ -29,6 +29,47 @@ const EMERALD = "hsl(158, 64%, 52%)"
 const FIELD_ORANGE = "hsl(28, 85%, 55%)"
 const AGG_FUNCTIONS = ["SUM", "AVG", "COUNT_ITER"] as const
 
+/** Split the expression into colored spans so the overlay layer shows
+ *  @field / @input / @output / @cross refs in their reference colors.
+ *  Cross-refs use the display form `@EstName.var` after idsToNames. */
+function renderHighlighted(
+  expr: string,
+  inputKeys: string[],
+  outputKeys: string[],
+  fieldKeys: string[],
+): React.ReactNode[] {
+  const inputs = new Set(inputKeys)
+  const outputs = new Set(outputKeys)
+  const fields = new Set(fieldKeys)
+  const nodes: React.ReactNode[] = []
+  // Matches @Name.var (cross-estimator display form) or @identifier
+  const re = /@([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)?)/g
+  let lastIdx = 0
+  let m: RegExpExecArray | null
+  let key = 0
+  while ((m = re.exec(expr)) !== null) {
+    if (m.index > lastIdx) nodes.push(expr.slice(lastIdx, m.index))
+    const body = m[1]
+    let color: string | undefined
+    if (body.includes(".")) color = ROSE
+    else if (inputs.has(body)) color = EMERALD
+    else if (outputs.has(body)) color = ROSE
+    else if (fields.has(body)) color = FIELD_ORANGE
+    nodes.push(
+      <span key={`t-${key++}`} style={color ? { color } : undefined}>
+        {m[0]}
+      </span>,
+    )
+    lastIdx = m.index + m[0].length
+  }
+  if (lastIdx < expr.length) nodes.push(expr.slice(lastIdx))
+  // Trailing newline needed so the overlay matches the textarea's line count
+  // when the user ends with a newline (textarea reserves a blank line, div
+  // would otherwise collapse it).
+  nodes.push(" ")
+  return nodes
+}
+
 type Suggestion = {
   label: string
   insert: string
@@ -320,8 +361,7 @@ export function OutputCard({
                   the layer only paints colored tokens. */}
               <div
                 aria-hidden
-                className="pointer-events-none absolute inset-0 whitespace-pre-wrap break-words font-mono text-sm px-3 py-2 rounded-md"
-                style={{ color: "transparent" }}
+                className="pointer-events-none absolute inset-0 whitespace-pre-wrap break-words font-mono text-sm px-3 py-2 rounded-md text-foreground"
               >
                 {renderHighlighted(
                   exprDraft,
@@ -332,8 +372,13 @@ export function OutputCard({
               </div>
               <Textarea
                 ref={exprRef}
-                className="relative text-sm font-mono min-h-[60px] resize-none bg-transparent"
-                style={{ color: "transparent", caretColor: "currentColor" }}
+                className="relative text-sm font-mono min-h-[60px] resize-none bg-transparent text-foreground"
+                style={{
+                  // Keep `color` at the theme foreground so the caret is
+                  // visible — only the glyph *fill* is transparent, so the
+                  // overlay layer handles rendering.
+                  WebkitTextFillColor: "transparent",
+                }}
                 placeholder="e.g. @surface * @prix_unitaire * 1.2"
                 value={exprDraft}
                 onChange={(e) => handleExpressionChange(e.target.value)}


### PR DESCRIPTION
This pull request introduces significant improvements to the flow canvas and estimator details experience in the FerrisQuote web app. The main changes focus on enhancing the accuracy and usability of estimator input wiring, especially when dealing with repeatable steps, and ensuring the UI prevents ambiguous or invalid configurations. Additional UX refinements and codebase improvements are included.

**Flow wiring and execution context improvements:**

* The flow graph builder (`flow-canvas.tsx`) now visualizes estimator input bindings as colored edges, accurately distinguishing between field-to-input and binding-to-input connections, and ensures correct handle targeting even during local renames.
* The estimator details panel (`estimator-details-panel.tsx`) enforces that fields from repeatable steps can only be used if the execution context is set to loop over that step, preventing ambiguous references. The UI disables or hides invalid options and provides clear feedback and error messages. [[1]](diffhunk://#diff-6b7762ba488dac9b2aa275b61957ec37d8a1a54404c47a9c948002f803ef833cR149-R213) [[2]](diffhunk://#diff-6b7762ba488dac9b2aa275b61957ec37d8a1a54404c47a9c948002f803ef833cR576-R581) [[3]](diffhunk://#diff-6b7762ba488dac9b2aa275b61957ec37d8a1a54404c47a9c948002f803ef833cL638-R708) [[4]](diffhunk://#diff-6b7762ba488dac9b2aa275b61957ec37d8a1a54404c47a9c948002f803ef833cL666-R787) [[5]](diffhunk://#diff-6b7762ba488dac9b2aa275b61957ec37d8a1a54404c47a9c948002f803ef833cL728-R843)

**Flow creation and panel behavior:**

* When creating a new estimator via drag-and-drop, the system now automatically provisions an empty binding so the details panel immediately shows wiring and reduce sections, ensuring a consistent editing experience. [[1]](diffhunk://#diff-956afe800ec319186f9a681a4b340269294ad55674e45ae627a4ab83e81ec675R39-R54) [[2]](diffhunk://#diff-956afe800ec319186f9a681a4b340269294ad55674e45ae627a4ab83e81ec675R75) [[3]](diffhunk://#diff-956afe800ec319186f9a681a4b340269294ad55674e45ae627a4ab83e81ec675R89) [[4]](diffhunk://#diff-956afe800ec319186f9a681a4b340269294ad55674e45ae627a4ab83e81ec675L160-L163) [[5]](diffhunk://#diff-956afe800ec319186f9a681a4b340269294ad55674e45ae627a4ab83e81ec675R206) [[6]](diffhunk://#diff-cc9df7bae303bd3ea13560de68be1ef75a931bfb8e53ce753857c0f4e944912eR643)

**User experience enhancements:**

* The Toaster notification position is moved from bottom-right to top-center for better visibility.
* Input fields in the input card now blur (commit changes) on pressing Enter, streamlining keyboard workflows. [[1]](diffhunk://#diff-563d28bb2aa23fac89296bbca912074377bbb7df61f4f7b9ce750054083a4dd1R180-R182) [[2]](diffhunk://#diff-563d28bb2aa23fac89296bbca912074377bbb7df61f4f7b9ce750054083a4dd1R195-R197)
* Clicking the flow canvas background now prioritizes cancelling linking mode before closing the edit panel, improving interaction predictability.

**Internal codebase improvements:**

* The flow graph builder now receives both "raw" and overlaid estimator lists, and all bindings, to support robust handle resolution and edge rendering. [[1]](diffhunk://#diff-cc9df7bae303bd3ea13560de68be1ef75a931bfb8e53ce753857c0f4e944912eR110-R111) [[2]](diffhunk://#diff-cc9df7bae303bd3ea13560de68be1ef75a931bfb8e53ce753857c0f4e944912eL619-R753)

These changes collectively make flow editing more robust, prevent invalid configurations, and improve the overall user experience.